### PR TITLE
Ppconvertcmakeclean fix memory leaks

### DIFF
--- a/src/QMCTools/ppconvert/src/NLPPClass.cc
+++ b/src/QMCTools/ppconvert/src/NLPPClass.cc
@@ -11,9 +11,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-
-
-
 #include "NLPPClass.h"
 #include "XMLWriterClass2.h"
 #include "ParserClass.h"
@@ -23,17 +20,15 @@
 #include <stdlib.h>
 #include <cstdlib>
 
-void
-ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
-					bool writeVl)
+void ChannelPotentialClass::WriteChannelLog(XMLWriterClass& writer, bool writeVl)
 {
   std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a logarithmic grid:
   // r(i) = a*(exp(b*i) - 1)
   const int numPoints = 2001;
-  double end = Vl.grid.End();
-  double step  = 0.00625;
-  double scale = end/(expm1(step*(numPoints-1)));
+  double end          = Vl.grid.End();
+  double step         = 0.00625;
+  double scale        = end / (expm1(step * (numPoints - 1)));
   if (writeVl)
     writer.StartElement("vps");
   else
@@ -41,7 +36,8 @@ ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
   writer.WriteAttribute("principal-n", n_principal);
   writer.WriteAttribute("l", channels[l]);
   writer.WriteAttribute("spin", -1);
-  if (writeVl) {
+  if (writeVl)
+  {
     writer.WriteAttribute("cutoff", Cutoff);
     writer.WriteAttribute("occupation", Occupation);
   }
@@ -54,14 +50,17 @@ ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
   std::vector<double> data;
-  for (int i=0; i<numPoints; i++) {
-    double r  = scale * (expm1(step*i));
-    if (writeVl) {
-      double rmin = std::min (r, Vl.grid.End());
+  for (int i = 0; i < numPoints; i++)
+  {
+    double r = scale * (expm1(step * i));
+    if (writeVl)
+    {
+      double rmin = std::min(r, Vl.grid.End());
       data.push_back(Vlr(rmin));
     }
-    else {
-      r = std::min (r, ul.grid.End());
+    else
+    {
+      r = std::min(r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -72,15 +71,12 @@ ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
 }
 
 
-
-void
-ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
-					   double dr, double rmax, bool writeVl)
+void ChannelPotentialClass::WriteChannelLinear(XMLWriterClass& writer, double dr, double rmax, bool writeVl)
 {
   std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a linear grid
   // r(i) = dr * i
-  const int numPoints = (int)round(rmax/dr) + 1;
+  const int numPoints = (int)round(rmax / dr) + 1;
   if (writeVl)
     writer.StartElement("vps");
   else
@@ -88,7 +84,8 @@ ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
   writer.WriteAttribute("principal-n", n_principal);
   writer.WriteAttribute("l", channels[l]);
   writer.WriteAttribute("spin", -1);
-  if (writeVl) {
+  if (writeVl)
+  {
     writer.WriteAttribute("cutoff", Cutoff);
     writer.WriteAttribute("occupation", Occupation);
   }
@@ -97,21 +94,24 @@ ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
   writer.WriteAttribute("type", "linear");
   writer.WriteAttribute("units", "bohr");
   writer.WriteAttribute("ri", 0.0);
-  writer.WriteAttribute("rf", dr*(double)(numPoints-1));
+  writer.WriteAttribute("rf", dr * (double)(numPoints - 1));
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
   std::vector<double> data;
-  for (int i=0; i<numPoints; i++) {
-    double r  = dr*(double)i;
-    if (writeVl) {
-      r = std::min (r, ul.grid.End());
+  for (int i = 0; i < numPoints; i++)
+  {
+    double r = dr * (double)i;
+    if (writeVl)
+    {
+      r = std::min(r, ul.grid.End());
       if (r < Vl.grid.Start())
-  	data.push_back(0.0);
+        data.push_back(0.0);
       else
-  	data.push_back(Vlr(r));
+        data.push_back(Vlr(r));
     }
-    else {
-      r = std::min (r, ul.grid.End());
+    else
+    {
+      r = std::min(r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -122,184 +122,251 @@ ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
 }
 
 
-void
-PseudoClass::SetupMaps()
+void PseudoClass::SetupMaps()
 {
-  UnitToHartreeMap[std::string("hartree")] = 1.0;
+  UnitToHartreeMap[std::string("hartree")]  = 1.0;
   UnitToHartreeMap[std::string("hartrees")] = 1.0;
   UnitToHartreeMap[std::string("Hartrees")] = 1.0;
-  UnitToHartreeMap[std::string("rydberg")] = 0.5;
-  UnitToHartreeMap[std::string("ev")]      = 0.03674932595264097934;
+  UnitToHartreeMap[std::string("rydberg")]  = 0.5;
+  UnitToHartreeMap[std::string("ev")]       = 0.03674932595264097934;
 
   UnitToBohrMap[std::string("bohr")]     = 1.0;
   UnitToBohrMap[std::string("atomic")]   = 1.0;
   UnitToBohrMap[std::string("angstrom")] = 1.8897261;
 
-  XCMap[XC_LDA] ="LDA" ; XCRevMap["LDA"] =XC_LDA;  XCRevMap["lda"] =XC_LDA;
-  XCMap[XC_GGA] ="GGA" ; XCRevMap["GGA"] =XC_GGA;  XCRevMap["gga"] =XC_LDA;
-  XCMap[XC_HF]  ="HF"  ; XCRevMap["HF"]  =XC_HF;   XCRevMap["hf"]  =XC_LDA;
-  XCMap[XC_DF]  ="DF"  ; XCRevMap["DF"]  =XC_DF;   XCRevMap["df"]  =XC_DF;
-  XCMap[XC_NONE]="NONE"; XCRevMap["NONE"]=XC_NONE; XCRevMap["none"]=XC_NONE;
+  XCMap[XC_LDA]    = "LDA";
+  XCRevMap["LDA"]  = XC_LDA;
+  XCRevMap["lda"]  = XC_LDA;
+  XCMap[XC_GGA]    = "GGA";
+  XCRevMap["GGA"]  = XC_GGA;
+  XCRevMap["gga"]  = XC_LDA;
+  XCMap[XC_HF]     = "HF";
+  XCRevMap["HF"]   = XC_HF;
+  XCRevMap["hf"]   = XC_LDA;
+  XCMap[XC_DF]     = "DF";
+  XCRevMap["DF"]   = XC_DF;
+  XCRevMap["df"]   = XC_DF;
+  XCMap[XC_NONE]   = "NONE";
+  XCRevMap["NONE"] = XC_NONE;
+  XCRevMap["none"] = XC_NONE;
 
-  ChannelMap[0] = "s";  ChannelRevMap["s"] = 0;
-  ChannelMap[1] = "p";  ChannelRevMap["p"] = 1;
-  ChannelMap[2] = "d";  ChannelRevMap["d"] = 2;
-  ChannelMap[3] = "f";  ChannelRevMap["f"] = 3;
-  ChannelMap[4] = "g";  ChannelRevMap["g"] = 4;
-  ChannelMap[5] = "h";  ChannelRevMap["h"] = 5;
-  ChannelMap[6] = "i";  ChannelRevMap["i"] = 6;
-  ZToSymbolMap[1]   = "H";  ZToSymbolMap[2]   = "He";
-  ZToSymbolMap[3]   = "Li"; ZToSymbolMap[4]   = "Be";
-  ZToSymbolMap[5]   = "B";  ZToSymbolMap[6]   = "C";
-  ZToSymbolMap[7]   = "N";  ZToSymbolMap[8]   = "O";
-  ZToSymbolMap[9]   = "F";  ZToSymbolMap[10]  = "Ne";
-  ZToSymbolMap[11]  = "Na"; ZToSymbolMap[12]  = "Mg";
-  ZToSymbolMap[13]  = "Al"; ZToSymbolMap[14]  = "Si";
-  ZToSymbolMap[15]  = "P";  ZToSymbolMap[16]  = "S";
-  ZToSymbolMap[17]  = "Cl"; ZToSymbolMap[18]  = "Ar";
-  ZToSymbolMap[19]  = "K";  ZToSymbolMap[20]  = "Ca";
-  ZToSymbolMap[21]  = "Sc"; ZToSymbolMap[22]  = "Ti";
-  ZToSymbolMap[23]  = "V";  ZToSymbolMap[24]  = "Cr";
-  ZToSymbolMap[25]  = "Mn"; ZToSymbolMap[26]  = "Fe";
-  ZToSymbolMap[27]  = "Co"; ZToSymbolMap[28]  = "Ni";
-  ZToSymbolMap[29]  = "Cu"; ZToSymbolMap[30]  = "Zn";
-  ZToSymbolMap[31]  = "Ga"; ZToSymbolMap[32]  = "Ge";
-  ZToSymbolMap[33]  = "As"; ZToSymbolMap[34]  = "Se";
-  ZToSymbolMap[35]  = "Br"; ZToSymbolMap[36]  = "Kr";
-  ZToSymbolMap[37]  = "Rb"; ZToSymbolMap[38]  = "Sr";
-  ZToSymbolMap[39]  = "Y";  ZToSymbolMap[40]  = "Zr";
-  ZToSymbolMap[41]  = "Nb"; ZToSymbolMap[42]  = "Mo";
-  ZToSymbolMap[43]  = "Tc"; ZToSymbolMap[44]  = "Ru";
-  ZToSymbolMap[45]  = "Rh"; ZToSymbolMap[46]  = "Pd";
-  ZToSymbolMap[47]  = "Ag"; ZToSymbolMap[48]  = "Cd";
-  ZToSymbolMap[49]  = "In"; ZToSymbolMap[50]  = "Sn";
-  ZToSymbolMap[51]  = "Sb"; ZToSymbolMap[52]  = "Te";
-  ZToSymbolMap[53]  = "I";  ZToSymbolMap[54]  = "Xe";
-  ZToSymbolMap[55]  = "Cs"; ZToSymbolMap[56]  = "Ba";
-  ZToSymbolMap[57]  = "La"; ZToSymbolMap[58]  = "Ce";
-  ZToSymbolMap[59]  = "Pr"; ZToSymbolMap[60]  = "Nd";
-  ZToSymbolMap[61]  = "Pm"; ZToSymbolMap[62]  = "Sm";
-  ZToSymbolMap[63]  = "Eu"; ZToSymbolMap[64]  = "Gd";
-  ZToSymbolMap[65]  = "Tb"; ZToSymbolMap[66]  = "Dy";
-  ZToSymbolMap[67]  = "Ho"; ZToSymbolMap[68]  = "Er";
-  ZToSymbolMap[69]  = "Tm"; ZToSymbolMap[70]  = "Yb";
-  ZToSymbolMap[71]  = "Lu"; ZToSymbolMap[72]  = "Hf";
-  ZToSymbolMap[73]  = "Ta"; ZToSymbolMap[74]  = "W";
-  ZToSymbolMap[75]  = "Re"; ZToSymbolMap[76]  = "Os";
-  ZToSymbolMap[77]  = "Ir"; ZToSymbolMap[78]  = "Pt";
-  ZToSymbolMap[79]  = "Au"; ZToSymbolMap[80]  = "Hg";
-  ZToSymbolMap[81]  = "Tl"; ZToSymbolMap[82]  = "Pb";
-  ZToSymbolMap[83]  = "Bi"; ZToSymbolMap[84]  = "Po";
-  ZToSymbolMap[85]  = "At"; ZToSymbolMap[86]  = "Rn";
-  ZToSymbolMap[87]  = "Fr"; ZToSymbolMap[88]  = "Ra";
-  ZToSymbolMap[89]  = "Ac"; ZToSymbolMap[90]  = "Th";
-  ZToSymbolMap[91]  = "Pa"; ZToSymbolMap[92]  = "U";
-  ZToSymbolMap[93]  = "Np"; ZToSymbolMap[94]  = "Pu";
-  ZToSymbolMap[95]  = "Am"; ZToSymbolMap[96]  = "Cm";
-  ZToSymbolMap[97]  = "Bk"; ZToSymbolMap[98]  = "Cf";
-  ZToSymbolMap[99]  = "Es"; ZToSymbolMap[100] = "Fm";
-  ZToSymbolMap[101] = "Mc"; ZToSymbolMap[102] = "No";
-  ZToSymbolMap[103] = "Lw";
+  ChannelMap[0]      = "s";
+  ChannelRevMap["s"] = 0;
+  ChannelMap[1]      = "p";
+  ChannelRevMap["p"] = 1;
+  ChannelMap[2]      = "d";
+  ChannelRevMap["d"] = 2;
+  ChannelMap[3]      = "f";
+  ChannelRevMap["f"] = 3;
+  ChannelMap[4]      = "g";
+  ChannelRevMap["g"] = 4;
+  ChannelMap[5]      = "h";
+  ChannelRevMap["h"] = 5;
+  ChannelMap[6]      = "i";
+  ChannelRevMap["i"] = 6;
+  ZToSymbolMap[1]    = "H";
+  ZToSymbolMap[2]    = "He";
+  ZToSymbolMap[3]    = "Li";
+  ZToSymbolMap[4]    = "Be";
+  ZToSymbolMap[5]    = "B";
+  ZToSymbolMap[6]    = "C";
+  ZToSymbolMap[7]    = "N";
+  ZToSymbolMap[8]    = "O";
+  ZToSymbolMap[9]    = "F";
+  ZToSymbolMap[10]   = "Ne";
+  ZToSymbolMap[11]   = "Na";
+  ZToSymbolMap[12]   = "Mg";
+  ZToSymbolMap[13]   = "Al";
+  ZToSymbolMap[14]   = "Si";
+  ZToSymbolMap[15]   = "P";
+  ZToSymbolMap[16]   = "S";
+  ZToSymbolMap[17]   = "Cl";
+  ZToSymbolMap[18]   = "Ar";
+  ZToSymbolMap[19]   = "K";
+  ZToSymbolMap[20]   = "Ca";
+  ZToSymbolMap[21]   = "Sc";
+  ZToSymbolMap[22]   = "Ti";
+  ZToSymbolMap[23]   = "V";
+  ZToSymbolMap[24]   = "Cr";
+  ZToSymbolMap[25]   = "Mn";
+  ZToSymbolMap[26]   = "Fe";
+  ZToSymbolMap[27]   = "Co";
+  ZToSymbolMap[28]   = "Ni";
+  ZToSymbolMap[29]   = "Cu";
+  ZToSymbolMap[30]   = "Zn";
+  ZToSymbolMap[31]   = "Ga";
+  ZToSymbolMap[32]   = "Ge";
+  ZToSymbolMap[33]   = "As";
+  ZToSymbolMap[34]   = "Se";
+  ZToSymbolMap[35]   = "Br";
+  ZToSymbolMap[36]   = "Kr";
+  ZToSymbolMap[37]   = "Rb";
+  ZToSymbolMap[38]   = "Sr";
+  ZToSymbolMap[39]   = "Y";
+  ZToSymbolMap[40]   = "Zr";
+  ZToSymbolMap[41]   = "Nb";
+  ZToSymbolMap[42]   = "Mo";
+  ZToSymbolMap[43]   = "Tc";
+  ZToSymbolMap[44]   = "Ru";
+  ZToSymbolMap[45]   = "Rh";
+  ZToSymbolMap[46]   = "Pd";
+  ZToSymbolMap[47]   = "Ag";
+  ZToSymbolMap[48]   = "Cd";
+  ZToSymbolMap[49]   = "In";
+  ZToSymbolMap[50]   = "Sn";
+  ZToSymbolMap[51]   = "Sb";
+  ZToSymbolMap[52]   = "Te";
+  ZToSymbolMap[53]   = "I";
+  ZToSymbolMap[54]   = "Xe";
+  ZToSymbolMap[55]   = "Cs";
+  ZToSymbolMap[56]   = "Ba";
+  ZToSymbolMap[57]   = "La";
+  ZToSymbolMap[58]   = "Ce";
+  ZToSymbolMap[59]   = "Pr";
+  ZToSymbolMap[60]   = "Nd";
+  ZToSymbolMap[61]   = "Pm";
+  ZToSymbolMap[62]   = "Sm";
+  ZToSymbolMap[63]   = "Eu";
+  ZToSymbolMap[64]   = "Gd";
+  ZToSymbolMap[65]   = "Tb";
+  ZToSymbolMap[66]   = "Dy";
+  ZToSymbolMap[67]   = "Ho";
+  ZToSymbolMap[68]   = "Er";
+  ZToSymbolMap[69]   = "Tm";
+  ZToSymbolMap[70]   = "Yb";
+  ZToSymbolMap[71]   = "Lu";
+  ZToSymbolMap[72]   = "Hf";
+  ZToSymbolMap[73]   = "Ta";
+  ZToSymbolMap[74]   = "W";
+  ZToSymbolMap[75]   = "Re";
+  ZToSymbolMap[76]   = "Os";
+  ZToSymbolMap[77]   = "Ir";
+  ZToSymbolMap[78]   = "Pt";
+  ZToSymbolMap[79]   = "Au";
+  ZToSymbolMap[80]   = "Hg";
+  ZToSymbolMap[81]   = "Tl";
+  ZToSymbolMap[82]   = "Pb";
+  ZToSymbolMap[83]   = "Bi";
+  ZToSymbolMap[84]   = "Po";
+  ZToSymbolMap[85]   = "At";
+  ZToSymbolMap[86]   = "Rn";
+  ZToSymbolMap[87]   = "Fr";
+  ZToSymbolMap[88]   = "Ra";
+  ZToSymbolMap[89]   = "Ac";
+  ZToSymbolMap[90]   = "Th";
+  ZToSymbolMap[91]   = "Pa";
+  ZToSymbolMap[92]   = "U";
+  ZToSymbolMap[93]   = "Np";
+  ZToSymbolMap[94]   = "Pu";
+  ZToSymbolMap[95]   = "Am";
+  ZToSymbolMap[96]   = "Cm";
+  ZToSymbolMap[97]   = "Bk";
+  ZToSymbolMap[98]   = "Cf";
+  ZToSymbolMap[99]   = "Es";
+  ZToSymbolMap[100]  = "Fm";
+  ZToSymbolMap[101]  = "Mc";
+  ZToSymbolMap[102]  = "No";
+  ZToSymbolMap[103]  = "Lw";
 
-  ZToMassMap[  1] = 1.00794;
-  ZToMassMap[  2] = 4.002602;
-  ZToMassMap[  3] = 6.941;
-  ZToMassMap[  4] = 9.012182;
-  ZToMassMap[  5] = 10.811;
-  ZToMassMap[  6] = 12.0107;
-  ZToMassMap[  7] = 14.0067;
-  ZToMassMap[  8] = 15.9994;
-  ZToMassMap[  9] = 18.9984032;
-  ZToMassMap[ 10] = 20.1797;
-  ZToMassMap[ 11] = 22.98976928;
-  ZToMassMap[ 12] = 24.3050;
-  ZToMassMap[ 13] = 26.9815386;
-  ZToMassMap[ 14] = 28.0855;
-  ZToMassMap[ 15] = 30.973762;
-  ZToMassMap[ 16] = 32.065;
-  ZToMassMap[ 17] = 35.453;
-  ZToMassMap[ 18] = 39.948;
-  ZToMassMap[ 19] = 39.0983;
-  ZToMassMap[ 20] = 40.078;
-  ZToMassMap[ 21] = 44.955912;
-  ZToMassMap[ 22] = 47.867;
-  ZToMassMap[ 23] = 50.9415;
-  ZToMassMap[ 24] = 51.9961;
-  ZToMassMap[ 25] = 54.938049;
-  ZToMassMap[ 26] = 55.845;
-  ZToMassMap[ 27] = 58.933200;
-  ZToMassMap[ 28] = 58.6934;
-  ZToMassMap[ 29] = 63.546;
-  ZToMassMap[ 30] = 65.39;
-  ZToMassMap[ 31] = 69.723;
-  ZToMassMap[ 32] = 72.61;
-  ZToMassMap[ 33] = 74.92160;
-  ZToMassMap[ 34] = 78.96 ;
-  ZToMassMap[ 35] = 79.904;
-  ZToMassMap[ 36] = 83.80;
-  ZToMassMap[ 37] = 85.4678;
-  ZToMassMap[ 38] = 87.62;
-  ZToMassMap[ 39] = 88.90585;
-  ZToMassMap[ 40] = 91.224;
-  ZToMassMap[ 41] = 92.90638;
-  ZToMassMap[ 42] = 95.94;
-  ZToMassMap[ 43] = 98;
-  ZToMassMap[ 44] = 101.07;
-  ZToMassMap[ 45] = 102.90550;
-  ZToMassMap[ 46] = 106.42;
-  ZToMassMap[ 47] = 107.8682;
-  ZToMassMap[ 48] = 112.411;
-  ZToMassMap[ 49] = 114.818;
-  ZToMassMap[ 50] = 118.710;
-  ZToMassMap[ 51] = 121.760;
-  ZToMassMap[ 52] = 127.60;
-  ZToMassMap[ 53] = 126.90447;
-  ZToMassMap[ 54] = 131.29;
-  ZToMassMap[ 55] = 132.90545;
-  ZToMassMap[ 56] = 137.327;
-  ZToMassMap[ 57] = 138.9055;
-  ZToMassMap[ 58] = 140.116;
-  ZToMassMap[ 59] = 140.90765;
-  ZToMassMap[ 60] = 144.24;
-  ZToMassMap[ 61] = 145;
-  ZToMassMap[ 62] = 150.36;
-  ZToMassMap[ 63] = 151.964;
-  ZToMassMap[ 64] = 157.25;
-  ZToMassMap[ 65] = 158.92534;
-  ZToMassMap[ 66] = 162.50;
-  ZToMassMap[ 67] = 164.93032;
-  ZToMassMap[ 68] = 167.26;
-  ZToMassMap[ 69] = 168.93421;
-  ZToMassMap[ 70] = 173.04;
-  ZToMassMap[ 71] = 174.967;
-  ZToMassMap[ 72] = 178.49;
-  ZToMassMap[ 73] = 180.9479;
-  ZToMassMap[ 74] = 183.84;
-  ZToMassMap[ 75] = 186.207;
-  ZToMassMap[ 76] = 190.23;
-  ZToMassMap[ 77] = 192.217;
-  ZToMassMap[ 78] = 195.078;
-  ZToMassMap[ 79] = 196.96655;
-  ZToMassMap[ 80] = 200.59;
-  ZToMassMap[ 81] = 204.3833;
-  ZToMassMap[ 82] = 207.2;
-  ZToMassMap[ 83] = 208.98038;
-  ZToMassMap[ 84] = 209;
-  ZToMassMap[ 85] = 210;
-  ZToMassMap[ 86] = 222;
-  ZToMassMap[ 87] = 223;
-  ZToMassMap[ 88] = 226;
-  ZToMassMap[ 89] = 227;
-  ZToMassMap[ 90] = 232.0381;
-  ZToMassMap[ 91] = 231.03588;
-  ZToMassMap[ 92] = 238.0289;
-  ZToMassMap[ 93] = 237;
-  ZToMassMap[ 94] = 244;
-  ZToMassMap[ 95] = 243;
-  ZToMassMap[ 96] = 247;
-  ZToMassMap[ 97] = 247;
-  ZToMassMap[ 98] = 251;
-  ZToMassMap[ 99] = 252;
+  ZToMassMap[1]   = 1.00794;
+  ZToMassMap[2]   = 4.002602;
+  ZToMassMap[3]   = 6.941;
+  ZToMassMap[4]   = 9.012182;
+  ZToMassMap[5]   = 10.811;
+  ZToMassMap[6]   = 12.0107;
+  ZToMassMap[7]   = 14.0067;
+  ZToMassMap[8]   = 15.9994;
+  ZToMassMap[9]   = 18.9984032;
+  ZToMassMap[10]  = 20.1797;
+  ZToMassMap[11]  = 22.98976928;
+  ZToMassMap[12]  = 24.3050;
+  ZToMassMap[13]  = 26.9815386;
+  ZToMassMap[14]  = 28.0855;
+  ZToMassMap[15]  = 30.973762;
+  ZToMassMap[16]  = 32.065;
+  ZToMassMap[17]  = 35.453;
+  ZToMassMap[18]  = 39.948;
+  ZToMassMap[19]  = 39.0983;
+  ZToMassMap[20]  = 40.078;
+  ZToMassMap[21]  = 44.955912;
+  ZToMassMap[22]  = 47.867;
+  ZToMassMap[23]  = 50.9415;
+  ZToMassMap[24]  = 51.9961;
+  ZToMassMap[25]  = 54.938049;
+  ZToMassMap[26]  = 55.845;
+  ZToMassMap[27]  = 58.933200;
+  ZToMassMap[28]  = 58.6934;
+  ZToMassMap[29]  = 63.546;
+  ZToMassMap[30]  = 65.39;
+  ZToMassMap[31]  = 69.723;
+  ZToMassMap[32]  = 72.61;
+  ZToMassMap[33]  = 74.92160;
+  ZToMassMap[34]  = 78.96;
+  ZToMassMap[35]  = 79.904;
+  ZToMassMap[36]  = 83.80;
+  ZToMassMap[37]  = 85.4678;
+  ZToMassMap[38]  = 87.62;
+  ZToMassMap[39]  = 88.90585;
+  ZToMassMap[40]  = 91.224;
+  ZToMassMap[41]  = 92.90638;
+  ZToMassMap[42]  = 95.94;
+  ZToMassMap[43]  = 98;
+  ZToMassMap[44]  = 101.07;
+  ZToMassMap[45]  = 102.90550;
+  ZToMassMap[46]  = 106.42;
+  ZToMassMap[47]  = 107.8682;
+  ZToMassMap[48]  = 112.411;
+  ZToMassMap[49]  = 114.818;
+  ZToMassMap[50]  = 118.710;
+  ZToMassMap[51]  = 121.760;
+  ZToMassMap[52]  = 127.60;
+  ZToMassMap[53]  = 126.90447;
+  ZToMassMap[54]  = 131.29;
+  ZToMassMap[55]  = 132.90545;
+  ZToMassMap[56]  = 137.327;
+  ZToMassMap[57]  = 138.9055;
+  ZToMassMap[58]  = 140.116;
+  ZToMassMap[59]  = 140.90765;
+  ZToMassMap[60]  = 144.24;
+  ZToMassMap[61]  = 145;
+  ZToMassMap[62]  = 150.36;
+  ZToMassMap[63]  = 151.964;
+  ZToMassMap[64]  = 157.25;
+  ZToMassMap[65]  = 158.92534;
+  ZToMassMap[66]  = 162.50;
+  ZToMassMap[67]  = 164.93032;
+  ZToMassMap[68]  = 167.26;
+  ZToMassMap[69]  = 168.93421;
+  ZToMassMap[70]  = 173.04;
+  ZToMassMap[71]  = 174.967;
+  ZToMassMap[72]  = 178.49;
+  ZToMassMap[73]  = 180.9479;
+  ZToMassMap[74]  = 183.84;
+  ZToMassMap[75]  = 186.207;
+  ZToMassMap[76]  = 190.23;
+  ZToMassMap[77]  = 192.217;
+  ZToMassMap[78]  = 195.078;
+  ZToMassMap[79]  = 196.96655;
+  ZToMassMap[80]  = 200.59;
+  ZToMassMap[81]  = 204.3833;
+  ZToMassMap[82]  = 207.2;
+  ZToMassMap[83]  = 208.98038;
+  ZToMassMap[84]  = 209;
+  ZToMassMap[85]  = 210;
+  ZToMassMap[86]  = 222;
+  ZToMassMap[87]  = 223;
+  ZToMassMap[88]  = 226;
+  ZToMassMap[89]  = 227;
+  ZToMassMap[90]  = 232.0381;
+  ZToMassMap[91]  = 231.03588;
+  ZToMassMap[92]  = 238.0289;
+  ZToMassMap[93]  = 237;
+  ZToMassMap[94]  = 244;
+  ZToMassMap[95]  = 243;
+  ZToMassMap[96]  = 247;
+  ZToMassMap[97]  = 247;
+  ZToMassMap[98]  = 251;
+  ZToMassMap[99]  = 252;
   ZToMassMap[100] = 257;
   ZToMassMap[101] = 258;
   ZToMassMap[102] = 259;
@@ -320,26 +387,21 @@ PseudoClass::SetupMaps()
   ZToMassMap[117] = 293; // UNKNOWN
   ZToMassMap[118] = 294;
 
-  for (int i=1; i<103; i++)
+  for (int i = 1; i < 103; i++)
     SymbolToZMap[ZToSymbolMap[i]] = i;
 }
 
-void
-PseudoClass::WriteFPMD(std::string fname)
+void PseudoClass::WriteFPMD(std::string fname)
 {
   const int numPoints = 2000;
-  const double dr = 0.005;
+  const double dr     = 0.005;
 
   XMLWriterClass writer;
   writer.StartDocument(fname, "1.0", "UTF-8");
   writer.StartElement("fpmd:species");
-  writer.WriteAttribute("xmlns:fpmd",
-			"http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0");
-  writer.WriteAttribute("xmlns:xsi",
-			"http://www.w3.org/2001/XMLSchema-instance");
-  writer.WriteAttribute
-    ("xsi:schemaLocation",
-     "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0 species.xsd");
+  writer.WriteAttribute("xmlns:fpmd", "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0");
+  writer.WriteAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+  writer.WriteAttribute("xsi:schemaLocation", "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0 species.xsd");
 
   writer.StartElement("description");
   writer.WriteData("ppconvert");
@@ -364,7 +426,7 @@ PseudoClass::WriteFPMD(std::string fname)
   writer.EndElement(); // "valence_charge"
 
   writer.StartElement("lmax");
-  writer.WriteData(ChannelPotentials.size()-1);
+  writer.WriteData(ChannelPotentials.size() - 1);
   writer.EndElement(); // "lmax"
 
   writer.StartElement("llocal");
@@ -380,34 +442,37 @@ PseudoClass::WriteFPMD(std::string fname)
   writer.EndElement(); // "rquad"
 
 
-
   writer.StartElement("mesh_spacing");
   writer.WriteData(dr);
   writer.EndElement(); // "rquad"
 
-  for (int il=0; il<ChannelPotentials.size(); il++) {
-    ChannelPotentialClass &pot = ChannelPotentials[il];
+  for (int il = 0; il < ChannelPotentials.size(); il++)
+  {
+    ChannelPotentialClass& pot = ChannelPotentials[il];
     writer.StartElement("projector");
     writer.WriteAttribute("l", pot.l);
     writer.WriteAttribute("size", numPoints);
 
     writer.StartElement("radial_potential");
     std::vector<double> vl(numPoints);
-    for (int ir=0; ir<numPoints; ir++) {
-      double r = (double)ir*dr;
-      vl[ir] = (ir==0) ? pot.Vl(0.0) : pot.Vlr(r)/r;
+    for (int ir = 0; ir < numPoints; ir++)
+    {
+      double r = (double)ir * dr;
+      vl[ir]   = (ir == 0) ? pot.Vl(0.0) : pot.Vlr(r) / r;
     }
     writer.WriteData(vl);
     writer.EndElement(); // "radial_potential"
 
-    if (pot.HasProjector && pot.l != LocalChannel) {
+    if (pot.HasProjector && pot.l != LocalChannel)
+    {
       writer.StartElement("radial_function");
       std::vector<double> ul(numPoints);
-      for (int ir=0; ir<numPoints; ir++) {
-	double r = (ir==0) ? 1.0e-8 : (double)ir*dr;
-	ul[ir] = pot.ul(r)/r;
+      for (int ir = 0; ir < numPoints; ir++)
+      {
+        double r = (ir == 0) ? 1.0e-8 : (double)ir * dr;
+        ul[ir]   = pot.ul(r) / r;
       }
-      ul[0] = 2.0*ul[1] - ul[2];
+      ul[0] = 2.0 * ul[1] - ul[2];
       writer.WriteData(ul);
       writer.EndElement(); // "radial_function"
     }
@@ -416,83 +481,80 @@ PseudoClass::WriteFPMD(std::string fname)
   }
 
 
-
   writer.EndElement(); // "norm_conserving_pseudopotential"
   writer.EndElement(); // "fpmd:species"
   writer.EndDocument();
 }
 
-void
-PseudoClass::WriteCASINO(std::string fname)
+void PseudoClass::WriteCASINO(std::string fname)
 {
   const int numPoints = 10001;
-  const double rMax = 10.0;
+  const double rMax   = 10.0;
 
-  FILE *fout = fopen (fname.c_str(), "w");
-  if (!fout) {
+  FILE* fout = fopen(fname.c_str(), "w");
+  if (!fout)
+  {
     std::cerr << "Error trying to write " << fname << ".\n";
     abort();
   }
 
-  fprintf (fout, "Pseudopotential in real space for %s\n",
-	   ZToSymbolMap[AtomicNumber].c_str());
-  fprintf (fout, "Atomic number and pseudo-charge\n%d %1.2f\n",
-	   AtomicNumber, PseudoCharge);
-  fprintf (fout, "Energy units (rydberg/hartree/ev):\nrydberg\n");
-  fprintf (fout, "Angular momentum of local component (0=s,1=p,2=d..)\n%d\n",
-	   LocalChannel);
-  fprintf (fout, "NLRULE override (1) VMC/DMC (2) config gen "
-	   "(0 ==> input/default value)\n0 0\n");
-  fprintf (fout, "Number of grid points\n%d\n",
-	   numPoints);
-  fprintf (fout, "R(i) in atomic units\n");
-  for (int i=0; i<numPoints; i++) {
-    double r = (double) i/(double)(numPoints-1)*rMax;
-    fprintf (fout, "  %22.16e\n", r);
+  fprintf(fout, "Pseudopotential in real space for %s\n", ZToSymbolMap[AtomicNumber].c_str());
+  fprintf(fout, "Atomic number and pseudo-charge\n%d %1.2f\n", AtomicNumber, PseudoCharge);
+  fprintf(fout, "Energy units (rydberg/hartree/ev):\nrydberg\n");
+  fprintf(fout, "Angular momentum of local component (0=s,1=p,2=d..)\n%d\n", LocalChannel);
+  fprintf(fout,
+          "NLRULE override (1) VMC/DMC (2) config gen "
+          "(0 ==> input/default value)\n0 0\n");
+  fprintf(fout, "Number of grid points\n%d\n", numPoints);
+  fprintf(fout, "R(i) in atomic units\n");
+  for (int i = 0; i < numPoints; i++)
+  {
+    double r = (double)i / (double)(numPoints - 1) * rMax;
+    fprintf(fout, "  %22.16e\n", r);
   }
 
-  for (int l=0; l<ChannelPotentials.size(); l++) {
-    ChannelPotentialClass &pot = (l < ChannelPotentials.size()) ?
-      ChannelPotentials[l] : ChannelPotentials[LocalChannel];
-    if (l < ChannelPotentials.size() && l != pot.l) {
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
+    ChannelPotentialClass& pot =
+        (l < ChannelPotentials.size()) ? ChannelPotentials[l] : ChannelPotentials[LocalChannel];
+    if (l < ChannelPotentials.size() && l != pot.l)
+    {
       std::cerr << "Channel mismatch in WriteCASINO.\n";
       abort();
     }
-    fprintf (fout, "r*potential (L=%d) in Ry\n",
-	     l);
-    for (int i=0; i<numPoints; i++) {
-      double r = (double) i/(double)(numPoints-1)*rMax;
-      fprintf (fout, "  %22.16e\n",
-	       (i==0) ? 0.0 : 2.0*pot.Vlr(r));
+    fprintf(fout, "r*potential (L=%d) in Ry\n", l);
+    for (int i = 0; i < numPoints; i++)
+    {
+      double r = (double)i / (double)(numPoints - 1) * rMax;
+      fprintf(fout, "  %22.16e\n", (i == 0) ? 0.0 : 2.0 * pot.Vlr(r));
     }
   }
   fclose(fout);
 }
 
-void
-PseudoClass::WriteXML(std::string fname)
+void PseudoClass::WriteXML(std::string fname)
 {
-//   int rc;
-//   xmlTextWriterPtr writer = xmlNewTextWriterFilename (fname.c_str(), 0);
+  //   int rc;
+  //   xmlTextWriterPtr writer = xmlNewTextWriterFilename (fname.c_str(), 0);
 
-//   rc = xmlTextWriterStartDocument (writer, NULL, "UTF-8", NULL);
-//   // Start pseudo
-//   rc = xmlTextWriterStartElement(writer, (xmlChar*)"pseudo");
-//   rc = xmlTextWriterWriteAttribute
-//     (writer, (xmlChar*) "version", (xmlChar*)"0.5");
-//   rc = xmlTextWriterEndElement(writer); // "pseudo"
-//   rc = xmlTextWriterEndDocument (writer);
-//   xmlFreeTextWriter(writer);
-  for (int l=0; l<ChannelPotentials.size(); l++)
-    if (!ChannelPotentials[l].HasProjector) {
-      std::cerr << "Missing projector for l=" << l
-	   << ".  Aborting." << std::endl;
+  //   rc = xmlTextWriterStartDocument (writer, NULL, "UTF-8", NULL);
+  //   // Start pseudo
+  //   rc = xmlTextWriterStartElement(writer, (xmlChar*)"pseudo");
+  //   rc = xmlTextWriterWriteAttribute
+  //     (writer, (xmlChar*) "version", (xmlChar*)"0.5");
+  //   rc = xmlTextWriterEndElement(writer); // "pseudo"
+  //   rc = xmlTextWriterEndDocument (writer);
+  //   xmlFreeTextWriter(writer);
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+    if (!ChannelPotentials[l].HasProjector)
+    {
+      std::cerr << "Missing projector for l=" << l << ".  Aborting." << std::endl;
       exit(1);
     }
   XMLWriterClass writer;
   writer.StartDocument(fname, "1.0", "UTF-8");
   writer.StartElement("pseudo");
-  writer.WriteAttribute ("version", "0.5");
+  writer.WriteAttribute("version", "0.5");
   writer.StartElement("header");
   writer.WriteAttribute("symbol", ZToSymbolMap[AtomicNumber]);
   writer.WriteAttribute("atomic-number", (double)AtomicNumber);
@@ -513,27 +575,29 @@ PseudoClass::WriteXML(std::string fname)
 
   // NEVER USE LOG GRID
   // Leads to inaccuracy in qmcPACK
-  if (WriteLogGrid && false) {
+  if (WriteLogGrid && false)
+  {
     const int numPoints = 2001;
-    rmax = PotentialGrid.End();
-    double step  = 0.00625;
-    double scale = rmax/(expm1(step*(numPoints-1)));
+    rmax                = PotentialGrid.End();
+    double step         = 0.00625;
+    double scale        = rmax / (expm1(step * (numPoints - 1)));
     writer.StartElement("grid");
     writer.WriteAttribute("type", "log");
     writer.WriteAttribute("units", "bohr");
     writer.WriteAttribute("scale", scale, true);
     writer.WriteAttribute("step", step, true);
-    writer.WriteAttribute("npts", numPoints-1);
+    writer.WriteAttribute("npts", numPoints - 1);
     writer.EndElement(); // "grid"
   }
-  else {
-    rmax = std::min (10.0, PotentialGrid.End());
-    int numPoints = (int)round(rmax/grid_delta) + 1;
+  else
+  {
+    rmax          = std::min(10.0, PotentialGrid.End());
+    int numPoints = (int)round(rmax / grid_delta) + 1;
     writer.StartElement("grid");
     writer.WriteAttribute("type", "linear");
     writer.WriteAttribute("units", "bohr");
     writer.WriteAttribute("ri", 0.0);
-    writer.WriteAttribute("rf", grid_delta*(double)(numPoints-1), true);
+    writer.WriteAttribute("rf", grid_delta * (double)(numPoints - 1), true);
     writer.WriteAttribute("npts", numPoints);
     writer.EndElement(); // "grid"
   }
@@ -542,26 +606,25 @@ PseudoClass::WriteXML(std::string fname)
   writer.WriteAttribute("units", "hartree");
   writer.WriteAttribute("format", "r*V");
   writer.WriteAttribute("npots-down", (int)ChannelPotentials.size());
-  writer.WriteAttribute("npots-up"  , 0);
+  writer.WriteAttribute("npots-up", 0);
   writer.WriteAttribute("l-local", LocalChannel);
-  for (int l=0; l<ChannelPotentials.size(); l++)
+  for (int l = 0; l < ChannelPotentials.size(); l++)
     if (WriteLogGrid && false)
-      ChannelPotentials[l].WriteChannelLog (writer, true);
+      ChannelPotentials[l].WriteChannelLog(writer, true);
     else
-      ChannelPotentials[l].WriteChannelLinear (writer, grid_delta, rmax, true);
+      ChannelPotentials[l].WriteChannelLinear(writer, grid_delta, rmax, true);
   writer.EndElement(); // "semilocal"
 
   writer.StartElement("pseudowave-functions");
   writer.WriteAttribute("units", "electrons/bohr^(-3/2)");
   writer.WriteAttribute("format", "u_n,l (r) = 1/r R_n,l (r)");
-  writer.WriteAttribute("n-pseudowave-functions-down",
-			(int)ChannelPotentials.size());
+  writer.WriteAttribute("n-pseudowave-functions-down", (int)ChannelPotentials.size());
   writer.WriteAttribute("n-pseudowave-functions-up", 0);
-  for (int l=0; l<ChannelPotentials.size(); l++)
+  for (int l = 0; l < ChannelPotentials.size(); l++)
     if (WriteLogGrid && false)
-      ChannelPotentials[l].WriteChannelLog (writer, false);
+      ChannelPotentials[l].WriteChannelLog(writer, false);
     else
-      ChannelPotentials[l].WriteChannelLinear (writer, grid_delta, rmax, false);
+      ChannelPotentials[l].WriteChannelLinear(writer, grid_delta, rmax, false);
   writer.EndElement(); // "pseudowave-functions"
 
   writer.EndElement(); // "pseudo"
@@ -569,29 +632,30 @@ PseudoClass::WriteXML(std::string fname)
 }
 
 
-void
-PseudoClass::Write4Block (FILE *fout, std::vector<double>& data, int indent)
+void PseudoClass::Write4Block(FILE* fout, std::vector<double>& data, int indent)
 {
   int N = data.size();
-  for (int i=0; i<N/4; i++) {
-    for (int j=0; j<indent; j++)   fprintf (fout, " ");
-    fprintf (fout, "%17.11e %1.17e %1.17e %1.17e\n",
-	     data[4*i+0], data[4*i+1], data[4*i+2], data[4*i+3]);
+  for (int i = 0; i < N / 4; i++)
+  {
+    for (int j = 0; j < indent; j++)
+      fprintf(fout, " ");
+    fprintf(fout, "%17.11e %1.17e %1.17e %1.17e\n", data[4 * i + 0], data[4 * i + 1], data[4 * i + 2], data[4 * i + 3]);
   }
-  int last = N/4;
-  for (int i=0; i<indent; i++)   fprintf (fout, " ");
-  for (int j=0; j<(N % 4); j++)
-    fprintf (fout, "%17.11e ", data[4*last+j]);
-  fprintf (fout, "\n");
+  int last = N / 4;
+  for (int i = 0; i < indent; i++)
+    fprintf(fout, " ");
+  for (int j = 0; j < (N % 4); j++)
+    fprintf(fout, "%17.11e ", data[4 * last + j]);
+  fprintf(fout, "\n");
 }
 
 
-void
-PseudoClass::WriteUPF (std::string fileName)
+void PseudoClass::WriteUPF(std::string fileName)
 {
   std::cerr << "LocalChannel = " << LocalChannel << std::endl;
-  FILE *fout = fopen (fileName.c_str(), "w");
-  if (fout == NULL) {
+  FILE* fout = fopen(fileName.c_str(), "w");
+  if (fout == NULL)
+  {
     std::cerr << "Error writing UPF file " << fileName << std::endl;
     return;
   }
@@ -599,279 +663,278 @@ PseudoClass::WriteUPF (std::string fileName)
   int N = PotentialGrid.NumPoints();
 
   // Write PP_INFO section
-  fprintf (fout, "<PP_INFO>\n");
-  fprintf (fout, "Generated using ppconvert\n");
+  fprintf(fout, "<PP_INFO>\n");
+  fprintf(fout, "Generated using ppconvert\n");
   // Get date
-  time_t now = time(NULL);
-  struct tm &ltime = *(localtime (&now));
+  time_t now       = time(NULL);
+  struct tm& ltime = *(localtime(&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((mon<10)  ? "0" : "") << mon << "/";
-  date << ((day<10)  ? "0" : "") << day << "/";
-  date << ((year<10) ? "0" : "") << year;
-  fprintf (fout, "Author:  Kenneth P. Esler  Generation date: %s\n",
-	   date.str().c_str());
+  date << ((mon < 10) ? "0" : "") << mon << "/";
+  date << ((day < 10) ? "0" : "") << day << "/";
+  date << ((year < 10) ? "0" : "") << year;
+  fprintf(fout, "Author:  Kenneth P. Esler  Generation date: %s\n", date.str().c_str());
 
 
-  fprintf (fout, "</PP_INFO>\n");
+  fprintf(fout, "</PP_INFO>\n");
 
   // Write PP_HEADER section
-  fprintf (fout, "<PP_HEADER>\n");
-  fprintf (fout, "   0                  Version Number\n");
-  fprintf (fout, "  %2s                  Element\n",
-	   ZToSymbolMap[AtomicNumber].c_str());
-  fprintf (fout, "  NC                  Norm - Conserving pseudopotential\n");
-  fprintf (fout, "   F                  Nonlinear Core Correction\n");
+  fprintf(fout, "<PP_HEADER>\n");
+  fprintf(fout, "   0                  Version Number\n");
+  fprintf(fout, "  %2s                  Element\n", ZToSymbolMap[AtomicNumber].c_str());
+  fprintf(fout, "  NC                  Norm - Conserving pseudopotential\n");
+  fprintf(fout, "   F                  Nonlinear Core Correction\n");
   std::string F_EX, F_CORR, F_XC_GRAD, F_CORR_GRAD;
-  F_EX = "SLA";
-  F_CORR = "PW";
-  F_XC_GRAD = "PBE";
+  F_EX        = "SLA";
+  F_CORR      = "PW";
+  F_XC_GRAD   = "PBE";
   F_CORR_GRAD = "PBE";
-  fprintf (fout, " %4s %4s %4s %4s  Exchange-Corelation functional\n",
-	   F_EX.c_str(), F_CORR.c_str(), F_XC_GRAD.c_str(), F_CORR_GRAD.c_str());
-  fprintf (fout, "  %1.10f        Z valence\n",
-	   PseudoCharge);
-  fprintf (fout, "  %1.10f       Total energy\n", TotalEnergy);
-  fprintf (fout, "  %3.6f  %3.6f  Suggested cutoff for wfc and rho\n",
-	   0.0, 0.0);
-  fprintf (fout, "  %ld                   Max angular momentum component\n",
-	   ChannelPotentials.size()-1);
-  fprintf (fout, "  %4d                Number of points in mesh\n",
-	   N);
-  fprintf (fout, "  %ld   %ld               Number of Wavefunctions, Number of Projectors\n", ChannelPotentials.size(), ChannelPotentials.size()-1);
-  fprintf (fout, " WaveFunctions      nl   l   occ    \n");
-  for (int l=0; l<ChannelPotentials.size(); l++)
-    fprintf (fout, "                    %d%s   %d   %1.4f\n",
-	     ChannelPotentials[l].n_principal,
-	     ChannelMap[l].c_str(),
-	     ChannelPotentials[l].l,
-	     ChannelPotentials[l].Occupation);
+  fprintf(fout, " %4s %4s %4s %4s  Exchange-Corelation functional\n", F_EX.c_str(), F_CORR.c_str(), F_XC_GRAD.c_str(),
+          F_CORR_GRAD.c_str());
+  fprintf(fout, "  %1.10f        Z valence\n", PseudoCharge);
+  fprintf(fout, "  %1.10f       Total energy\n", TotalEnergy);
+  fprintf(fout, "  %3.6f  %3.6f  Suggested cutoff for wfc and rho\n", 0.0, 0.0);
+  fprintf(fout, "  %ld                   Max angular momentum component\n", ChannelPotentials.size() - 1);
+  fprintf(fout, "  %4d                Number of points in mesh\n", N);
+  fprintf(fout, "  %ld   %ld               Number of Wavefunctions, Number of Projectors\n", ChannelPotentials.size(),
+          ChannelPotentials.size() - 1);
+  fprintf(fout, " WaveFunctions      nl   l   occ    \n");
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+    fprintf(fout, "                    %d%s   %d   %1.4f\n", ChannelPotentials[l].n_principal, ChannelMap[l].c_str(),
+            ChannelPotentials[l].l, ChannelPotentials[l].Occupation);
 
-  fprintf (fout, "</PP_HEADER>\n");
+  fprintf(fout, "</PP_HEADER>\n");
 
   // Write PP_MESH section
-  fprintf (fout, "<PP_MESH>\n");
-  fprintf (fout, "  <PP_R>\n");
-  Write4Block (fout, PotentialGrid.Points());
-  fprintf (fout, "  </PP_R>\n");
-  fprintf (fout, "  <PP_RAB>\n");
+  fprintf(fout, "<PP_MESH>\n");
+  fprintf(fout, "  <PP_R>\n");
+  Write4Block(fout, PotentialGrid.Points());
+  fprintf(fout, "  </PP_R>\n");
+  fprintf(fout, "  <PP_RAB>\n");
   std::vector<double> dr(N);
-  for (int i=1; i<(N-1); i++)
-    dr[i] = 0.5*(PotentialGrid[i+1]-PotentialGrid[i-1]);
-  dr[0]   = 2.0*dr[ 1 ]-dr[ 2 ];
-  dr[N-1] = 2.0*dr[N-2]-dr[N-3];
+  for (int i = 1; i < (N - 1); i++)
+    dr[i] = 0.5 * (PotentialGrid[i + 1] - PotentialGrid[i - 1]);
+  dr[0]     = 2.0 * dr[1] - dr[2];
+  dr[N - 1] = 2.0 * dr[N - 2] - dr[N - 3];
 
-  Write4Block (fout, dr);
-  fprintf (fout, "  </PP_RAB>\n");
-  fprintf (fout, "</PP_MESH>\n");
+  Write4Block(fout, dr);
+  fprintf(fout, "  </PP_RAB>\n");
+  fprintf(fout, "</PP_MESH>\n");
 
   // Write PP_LOCAL section
-  fprintf (fout, "<PP_LOCAL>\n");
+  fprintf(fout, "<PP_LOCAL>\n");
   std::vector<double> vloc(N);
-  for (int i=0; i<N; i++)
-    vloc[i] = 2.0*ChannelPotentials[LocalChannel].Vl(i); // /PotentialGrid[i];
+  for (int i = 0; i < N; i++)
+    vloc[i] = 2.0 * ChannelPotentials[LocalChannel].Vl(i); // /PotentialGrid[i];
   //vloc[0] = 2.0*ChannelPotentials[LocalChannel].Vl(1.0e-7)/1.0e-7;
-  Write4Block (fout, vloc);
-  fprintf (fout, "</PP_LOCAL>\n");
+  Write4Block(fout, vloc);
+  fprintf(fout, "</PP_LOCAL>\n");
 
   // Write the nonlocal section
-  fprintf (fout, "<PP_NONLOCAL>\n");
+  fprintf(fout, "<PP_NONLOCAL>\n");
   int betaNum = 1;
-  for (int l=0; l<ChannelPotentials.size(); l++)
-    if (l != LocalChannel) {
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+    if (l != LocalChannel)
+    {
       std::vector<double> beta(N);
-      for (int i=0; i<N; i++) {
-	double Vloc = ChannelPotentials[LocalChannel].Vlr(i);
-	double Vl   = ChannelPotentials[l].Vlr(i);
-	double ul   = ChannelPotentials[l].ul(i);
-	double r    = PotentialGrid[i];
-	beta[i] = 2.0*ul*(Vl - Vloc)/r;
-	//beta[i] = 2.0*ul*(Vl - Vloc);
-	//beta[i] = 2.0*r*ul*(Vl - Vloc);
+      for (int i = 0; i < N; i++)
+      {
+        double Vloc = ChannelPotentials[LocalChannel].Vlr(i);
+        double Vl   = ChannelPotentials[l].Vlr(i);
+        double ul   = ChannelPotentials[l].ul(i);
+        double r    = PotentialGrid[i];
+        beta[i]     = 2.0 * ul * (Vl - Vloc) / r;
+        //beta[i] = 2.0*ul*(Vl - Vloc);
+        //beta[i] = 2.0*r*ul*(Vl - Vloc);
       }
-      beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
- 	(ChannelPotentials[l].Vlr(1.0e-7)-ChannelPotentials[LocalChannel].Vlr(1.0e-7))/1.0e-7;
-//       beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
-// 	(ChannelPotentials[l].Vl(1.0e-7)-ChannelPotentials[LocalChannel].Vl(1.0e-7));
-      fprintf (fout, "  <PP_BETA>\n");
-      fprintf (fout, "    %d %d             Beta L\n", betaNum, l);
-      fprintf (fout, "    %d  \n", N);
-      Write4Block (fout, beta, 4);
-      fprintf (fout, "  </PP_BETA>\n");
+      beta[0] = 2.0 * ChannelPotentials[l].ul(0.0) *
+          (ChannelPotentials[l].Vlr(1.0e-7) - ChannelPotentials[LocalChannel].Vlr(1.0e-7)) / 1.0e-7;
+      //       beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
+      // 	(ChannelPotentials[l].Vl(1.0e-7)-ChannelPotentials[LocalChannel].Vl(1.0e-7));
+      fprintf(fout, "  <PP_BETA>\n");
+      fprintf(fout, "    %d %d             Beta L\n", betaNum, l);
+      fprintf(fout, "    %d  \n", N);
+      Write4Block(fout, beta, 4);
+      fprintf(fout, "  </PP_BETA>\n");
       betaNum++;
     }
   // Write D_ij matrix
-  fprintf (fout, "  <PP_DIJ>\n");
-  fprintf (fout, "    %ld         Number of nonzero Dij\n",
-	   ChannelPotentials.size()-1);
+  fprintf(fout, "  <PP_DIJ>\n");
+  fprintf(fout, "    %ld         Number of nonzero Dij\n", ChannelPotentials.size() - 1);
   betaNum = 1;
   // Compute D_ij matrix.  In our case, with single projectors, D_ij
   // is diagonal.  The elements are
   // D_ll = 1.0/<u_l |Vl - Vloc | u_l>
   // We will numerically integrate with Simpson's rule
-  for (int l=0; l<ChannelPotentials.size(); l++)
-    if (l != LocalChannel) {
-      const int M = 100000;
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+    if (l != LocalChannel)
+    {
+      const int M   = 100000;
       double DijInv = 0.0;
-      double norm = 0.0;
-      double dr = PotentialGrid[N-1]/(double)(M);
-      double third = 1.0/3.0;
+      double norm   = 0.0;
+      double dr     = PotentialGrid[N - 1] / (double)(M);
+      double third  = 1.0 / 3.0;
       double prefactor;
       double r = 1.0e-8;
-      for (int i=0; i<=M; i++) {
-	double Vl   = ChannelPotentials[l].Vlr(r)/r;
-	double Vloc = ChannelPotentials[LocalChannel].Vlr(r)/r;
-	double u = ChannelPotentials[l].ul(r);
-	// Prefactors for Simpsons's rule
-	if ((i==0) || (i==M))
-	  prefactor = third;
-	else if ((i&1)==1)
-	  prefactor = 4.0* third;
-	else
-	  prefactor = 2.0*third;
-	DijInv += prefactor*dr *u * u * 2.0 * (Vl - Vloc);
-	norm += prefactor*u*u*dr;
-	r += dr;
+      for (int i = 0; i <= M; i++)
+      {
+        double Vl   = ChannelPotentials[l].Vlr(r) / r;
+        double Vloc = ChannelPotentials[LocalChannel].Vlr(r) / r;
+        double u    = ChannelPotentials[l].ul(r);
+        // Prefactors for Simpsons's rule
+        if ((i == 0) || (i == M))
+          prefactor = third;
+        else if ((i & 1) == 1)
+          prefactor = 4.0 * third;
+        else
+          prefactor = 2.0 * third;
+        DijInv += prefactor * dr * u * u * 2.0 * (Vl - Vloc);
+        norm += prefactor * u * u * dr;
+        r += dr;
       }
-      double Dij = 1.0/DijInv;
-      fprintf (fout, "    %d %d  %1.20e\n", betaNum, betaNum, Dij);
-      fprintf (stderr, "l = %d, betaNum = %d, norm = %1.10e  Dij = %1.10e\n",
-	       l, betaNum, norm, Dij);
+      double Dij = 1.0 / DijInv;
+      fprintf(fout, "    %d %d  %1.20e\n", betaNum, betaNum, Dij);
+      fprintf(stderr, "l = %d, betaNum = %d, norm = %1.10e  Dij = %1.10e\n", l, betaNum, norm, Dij);
       betaNum++;
     }
-  fprintf (fout, "  </PP_DIJ>\n");
-  fprintf (fout, "</PP_NONLOCAL>\n");
+  fprintf(fout, "  </PP_DIJ>\n");
+  fprintf(fout, "</PP_NONLOCAL>\n");
 
   // Write PP_PSWFC section
-  fprintf (fout, "<PP_PSWFC>\n");
-  for (int l=0; l<ChannelPotentials.size(); l++) {
-    ChannelPotentialClass &pot = ChannelPotentials[l];
-    fprintf (fout, "%d%s    %d  %6.4f          Wavefunction\n",
-	     pot.n_principal, ChannelMap[l].c_str(), l, pot.Occupation);
+  fprintf(fout, "<PP_PSWFC>\n");
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
+    ChannelPotentialClass& pot = ChannelPotentials[l];
+    fprintf(fout, "%d%s    %d  %6.4f          Wavefunction\n", pot.n_principal, ChannelMap[l].c_str(), l,
+            pot.Occupation);
     std::vector<double> u(N);
-    for (int i=0; i<N; i++)
+    for (int i = 0; i < N; i++)
       u[i] = pot.ul(i);
-    Write4Block (fout, u);
+    Write4Block(fout, u);
   }
-  fprintf (fout, "</PP_PSWFC>\n");
+  fprintf(fout, "</PP_PSWFC>\n");
 
   // Write PP_RHOATOM section
-  fprintf (fout, "<PP_RHOATOM>\n");
+  fprintf(fout, "<PP_RHOATOM>\n");
   std::vector<double> rho_at(N);
-  for (int i=0; i<N; i++) {
+  for (int i = 0; i < N; i++)
+  {
     if (RhoAtom.Initialized)
-      rho_at[i] = RhoAtom(i)*PotentialGrid[i]*PotentialGrid[i];
-    else {
+      rho_at[i] = RhoAtom(i) * PotentialGrid[i] * PotentialGrid[i];
+    else
+    {
       rho_at[i] = 0.0;
-      for (int l=0; l<ChannelPotentials.size(); l++) {
-	ChannelPotentialClass &pot = ChannelPotentials[l];
-	double u = pot.ul(i);
-	rho_at[i] += pot.Occupation * u*u;
+      for (int l = 0; l < ChannelPotentials.size(); l++)
+      {
+        ChannelPotentialClass& pot = ChannelPotentials[l];
+        double u                   = pot.ul(i);
+        rho_at[i] += pot.Occupation * u * u;
       }
     }
   }
-  Write4Block (fout, rho_at);
+  Write4Block(fout, rho_at);
 
-  fprintf (fout, "</PP_RHOATOM>\n");
+  fprintf(fout, "</PP_RHOATOM>\n");
 
   // Close the file
-  fclose (fout);
+  fclose(fout);
 }
 
 
-void
-PseudoClass::WriteFHI (std::string fileName)
+void PseudoClass::WriteFHI(std::string fileName)
 {
-  const double amesh =  1.013084867359809;
+  const double amesh  = 1.013084867359809;
   const int numPoints = 1118;
 
 
-  FILE *fout = fopen (fileName.c_str(), "w");
-  assert (fout != NULL);
+  FILE* fout = fopen(fileName.c_str(), "w");
+  assert(fout != NULL);
   // Write ABINIT header
-  fprintf (fout, "Written by ppconvert:  %s psuedopotential\n",
-	   ZToSymbolMap[AtomicNumber].c_str());
-  time_t now = time(NULL);
-  struct tm &ltime = *(localtime (&now));
+  fprintf(fout, "Written by ppconvert:  %s psuedopotential\n", ZToSymbolMap[AtomicNumber].c_str());
+  time_t now       = time(NULL);
+  struct tm& ltime = *(localtime(&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((year<10) ? "0" : "") << year;
-  date << ((mon<10)  ? "0" : "") << mon;
-  date << ((day<10)  ? "0" : "") << day;
+  date << ((year < 10) ? "0" : "") << year;
+  date << ((mon < 10) ? "0" : "") << mon;
+  date << ((day < 10) ? "0" : "") << day;
 
-  fprintf (fout, "%9.5f %9.5f %s"
-	   "                    zatom, zion, pspdat\n", (double)AtomicNumber,
-	   PseudoCharge, date.str().c_str());
+  fprintf(fout,
+          "%9.5f %9.5f %s"
+          "                    zatom, zion, pspdat\n",
+          (double)AtomicNumber, PseudoCharge, date.str().c_str());
 
-  fprintf (fout, "    6   7  %ld  %d  %d  0.0000     "
-	   "pspcod,pspxc,lmax,lloc,mmax,r2well\n",
-	   ChannelPotentials.size()-1, LocalChannel, numPoints);
-  fprintf (fout, "   0.00000   0.00000   0.00000                  "
-	   "rchrg,fchrg,qchrg\n");
-  fprintf (fout, "5 --- reserved for future features\n"
-	   "6 --- reserved for future features\n"
-	   "7 --- Here follows the cpi file in the fhi98pp format -\n");
+  fprintf(fout,
+          "    6   7  %ld  %d  %d  0.0000     "
+          "pspcod,pspxc,lmax,lloc,mmax,r2well\n",
+          ChannelPotentials.size() - 1, LocalChannel, numPoints);
+  fprintf(fout,
+          "   0.00000   0.00000   0.00000                  "
+          "rchrg,fchrg,qchrg\n");
+  fprintf(fout,
+          "5 --- reserved for future features\n"
+          "6 --- reserved for future features\n"
+          "7 --- Here follows the cpi file in the fhi98pp format -\n");
 
   // Write FHI file proper
-  fprintf (fout, "%d %ld\n", (int)round(PseudoCharge),
-	   ChannelPotentials.size());
-  for (int i=0; i<10; i++)
-    fprintf (fout, "0.0 0.0 0.0\n");
+  fprintf(fout, "%d %ld\n", (int)round(PseudoCharge), ChannelPotentials.size());
+  for (int i = 0; i < 10; i++)
+    fprintf(fout, "0.0 0.0 0.0\n");
 
-  for (int l=0; l<ChannelPotentials.size(); l++) {
-    fprintf (fout, "%d %1.18f\n", numPoints, amesh);
-    double r = 5.848035476425733e-05;
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
+    fprintf(fout, "%d %1.18f\n", numPoints, amesh);
+    double r   = 5.848035476425733e-05;
     double nrm = 0.0;
-    for (int i=0; i<numPoints; i++) {
-      double Vl = ChannelPotentials[l].Vlr(r)/r;
+    for (int i = 0; i < numPoints; i++)
+    {
+      double Vl = ChannelPotentials[l].Vlr(r) / r;
       double ul = ChannelPotentials[l].ul(r);
-      nrm += 0.5*r*(amesh-1.0/amesh)*ul*ul;
+      nrm += 0.5 * r * (amesh - 1.0 / amesh) * ul * ul;
 
-      fprintf (fout, "%5d  %20.16e %20.16e %20.16e\n",
-	       i+1, r, ul, Vl);
+      fprintf(fout, "%5d  %20.16e %20.16e %20.16e\n", i + 1, r, ul, Vl);
       r *= amesh;
     }
-    fprintf (stderr, "Norm = %1.8f\n", nrm);
+    fprintf(stderr, "Norm = %1.8f\n", nrm);
   }
-  fclose (fout);
+  fclose(fout);
 }
 
 
-void
-PseudoClass::WriteABINIT (std::string fileName)
+void PseudoClass::WriteABINIT(std::string fileName)
 {
   if (fileName == "")
     fileName = ZToSymbolMap[AtomicNumber] + ".psp";
 
-  FILE *fout = fopen (fileName.c_str(), "w");
-  assert (fout != NULL);
+  FILE* fout = fopen(fileName.c_str(), "w");
+  assert(fout != NULL);
 
-  time_t now = time(NULL);
-  struct tm &ltime = *(localtime (&now));
+  time_t now       = time(NULL);
+  struct tm& ltime = *(localtime(&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((year<10) ? "0" : "") << year;
-  date << ((mon<10)  ? "0" : "") << mon;
-  date << ((day<10)  ? "0" : "")  << day;
+  date << ((year < 10) ? "0" : "") << year;
+  date << ((mon < 10) ? "0" : "") << mon;
+  date << ((day < 10) ? "0" : "") << day;
 
-  fprintf (fout, "%s  %s", ZToSymbolMap[AtomicNumber].c_str(),
-	   asctime(&ltime));
-  fprintf (fout, "%9.5f %9.5f %s"
-	   "                    zatom, zion, pspdat\n", (double)AtomicNumber,
-	   PseudoCharge, date.str().c_str());
+  fprintf(fout, "%s  %s", ZToSymbolMap[AtomicNumber].c_str(), asctime(&ltime));
+  fprintf(fout,
+          "%9.5f %9.5f %s"
+          "                    zatom, zion, pspdat\n",
+          (double)AtomicNumber, PseudoCharge, date.str().c_str());
   const int pspcod = 1;
   const int pspxc  = 0;
-  const int lmax   = ChannelPotentials.size()-1;
+  const int lmax   = ChannelPotentials.size() - 1;
   // HACK HACK HAK
-  const int lloc   = LocalChannel;
-  const int mmax  = 2001;
-  double r2well = 0.0;
+  const int lloc = LocalChannel;
+  const int mmax = 2001;
+  double r2well  = 0.0;
   // The following are informational only
   const double e99    = 0.0;
   const double e999   = 0.0;
@@ -883,193 +946,203 @@ PseudoClass::WriteABINIT (std::string fileName)
   const double rchrg  = 1.0;
   const double qchrg  = 0.0;
 
-  fprintf (fout, "%d   %d   %d   %d   %d   %8.5f"
-	   "              pspcod,pspxc,lmax,lloc,mmax,r2well\n",
-	   pspcod, pspxc, lmax, lloc, mmax, r2well);
+  fprintf(fout,
+          "%d   %d   %d   %d   %d   %8.5f"
+          "              pspcod,pspxc,lmax,lloc,mmax,r2well\n",
+          pspcod, pspxc, lmax, lloc, mmax, r2well);
 
-  for (int l=0; l<ChannelPotentials.size(); l++) {
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
     // The local channel needs no projector
     int nproj = (l == lloc) ? 0 : 1;
-    fprintf (fout, "%d %5.8f %5.8f %d %5.8f"
-	     "          l,e99.0,e99.9,nproj,rcpsp\n",
-	     l, e99, e999, nproj, ChannelPotentials[l].Cutoff);
-    fprintf (fout, "%14.10f %14.10f %14.10f %14.10f"
-	     "  rms,ekb1,ekb2,epsatm\n", rms, ekb1, ekb2, epsatm);
+    fprintf(fout,
+            "%d %5.8f %5.8f %d %5.8f"
+            "          l,e99.0,e99.9,nproj,rcpsp\n",
+            l, e99, e999, nproj, ChannelPotentials[l].Cutoff);
+    fprintf(fout,
+            "%14.10f %14.10f %14.10f %14.10f"
+            "  rms,ekb1,ekb2,epsatm\n",
+            rms, ekb1, ekb2, epsatm);
   }
-  fprintf (fout, "%8.5f %8.5f %8.5f"
-	   "                    rchrg,fchrg,qchrg\n", rchrg, fchrg, qchrg);
+  fprintf(fout,
+          "%8.5f %8.5f %8.5f"
+          "                    rchrg,fchrg,qchrg\n",
+          rchrg, fchrg, qchrg);
 
   // Write out potentials
-  for (int l=0; l<ChannelPotentials.size(); l++) {
-    fprintf (fout, "%d = l for CASINO pseudopotential\n", l);
-    for (int i=0; i<mmax; i++) {
-      double x = (double)i/(double)(mmax-1);
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
+    fprintf(fout, "%d = l for CASINO pseudopotential\n", l);
+    for (int i = 0; i < mmax; i++)
+    {
+      double x = (double)i / (double)(mmax - 1);
       x += 0.01;
-      double r = 100.0*x*x*x*x*x - 1.0e-8;
+      double r = 100.0 * x * x * x * x * x - 1.0e-8;
       double Vl;
       if (r >= ChannelPotentials[l].Vl.grid.End())
-	Vl = -1.0*PseudoCharge/r;
+        Vl = -1.0 * PseudoCharge / r;
       else
-	Vl = ChannelPotentials[l].Vl(r); // /r;
+        Vl = ChannelPotentials[l].Vl(r); // /r;
       double Vlold = Vl;
-      Vl = ChannelPotentials[l].Vlr(r)/r;
+      Vl           = ChannelPotentials[l].Vlr(r) / r;
       if (i == 0)
-	Vl = ChannelPotentials[l].Vl(0.0);
+        Vl = ChannelPotentials[l].Vl(0.0);
       // fprintf (stderr, "r = %1.10f  Interp diff = %1.8e\n", r, Vl-Vlold);
-      fprintf (fout, "%23.16e ", Vl);
-      if ((i%3)==2)
-	fprintf (fout, "\n");
+      fprintf(fout, "%23.16e ", Vl);
+      if ((i % 3) == 2)
+        fprintf(fout, "\n");
     }
   }
   // Now write out radial wave functions
-  for (int l=0; l<ChannelPotentials.size(); l++) {
-      fprintf (fout, "%d = l for CASINO wave function\n", l);
-      for (int i=0; i<mmax; i++) {
-	double x = (double)i/(double)(mmax-1);
-	x += 0.01;
-	double r = 100.0*x*x*x*x*x - 1.0e-8;
-	double ul;
-	double rend = ChannelPotentials[l].ul.grid.End();
-	if (r >= rend) {
-	  int i=ChannelPotentials[l].ul.grid.NumPoints();
-	  while (fabs(ChannelPotentials[l].ul(i)) == 0.0) i--;
-	  double r2 = ChannelPotentials[l].ul.grid[i];
-	  double r1 = ChannelPotentials[l].ul.grid[i-10];
-	  double u2 = ChannelPotentials[l].ul(i);
-	  double u1 = ChannelPotentials[l].ul(i-10);
-	  double alpha = log(u1/u2)/(r2-r1);
-	  // rend = min (rend, 60.0);
-	  // double uend = ChannelPotentials[l].ul(rend);
-	  // double alpha = log (ChannelPotentials[l].ul(rend-1.0)/uend);
-	  //cerr << "alpha = " << alpha << " rend = " << r2 << " u2 = " << u2 << endl;
-	  // ul = uend * exp(-alpha*(r-rend));
-	  ul = u2 * exp(-alpha*(r - r2));
-	}
-	else
-	  ul= ChannelPotentials[l].ul(r);
-	fprintf (fout, "%23.16e ", ul);
-	if ((i%3)==2)
-	  fprintf (fout, "\n");
+  for (int l = 0; l < ChannelPotentials.size(); l++)
+  {
+    fprintf(fout, "%d = l for CASINO wave function\n", l);
+    for (int i = 0; i < mmax; i++)
+    {
+      double x = (double)i / (double)(mmax - 1);
+      x += 0.01;
+      double r = 100.0 * x * x * x * x * x - 1.0e-8;
+      double ul;
+      double rend = ChannelPotentials[l].ul.grid.End();
+      if (r >= rend)
+      {
+        int i = ChannelPotentials[l].ul.grid.NumPoints();
+        while (fabs(ChannelPotentials[l].ul(i)) == 0.0)
+          i--;
+        double r2    = ChannelPotentials[l].ul.grid[i];
+        double r1    = ChannelPotentials[l].ul.grid[i - 10];
+        double u2    = ChannelPotentials[l].ul(i);
+        double u1    = ChannelPotentials[l].ul(i - 10);
+        double alpha = log(u1 / u2) / (r2 - r1);
+        // rend = min (rend, 60.0);
+        // double uend = ChannelPotentials[l].ul(rend);
+        // double alpha = log (ChannelPotentials[l].ul(rend-1.0)/uend);
+        //cerr << "alpha = " << alpha << " rend = " << r2 << " u2 = " << u2 << endl;
+        // ul = uend * exp(-alpha*(r-rend));
+        ul = u2 * exp(-alpha * (r - r2));
       }
+      else
+        ul = ChannelPotentials[l].ul(r);
+      fprintf(fout, "%23.16e ", ul);
+      if ((i % 3) == 2)
+        fprintf(fout, "\n");
+    }
   }
 
-  fclose (fout);
+  fclose(fout);
 }
 
-void
-PseudoClass::WriteASCII()
+void PseudoClass::WriteASCII()
 {
-  FILE *fout = fopen ("pp.dat", "w");
-  for (int i=1; i<PotentialGrid.NumPoints(); i++) {
-    double r= PotentialGrid[i];
-    fprintf (fout, "%24.16e ", r);
-    for (int l=0; l<ChannelPotentials.size(); l++)
-      fprintf (fout, "%24.16e ", ChannelPotentials[l].Vl(r));// /r);
-    fprintf (fout, "\n");
+  FILE* fout = fopen("pp.dat", "w");
+  for (int i = 1; i < PotentialGrid.NumPoints(); i++)
+  {
+    double r = PotentialGrid[i];
+    fprintf(fout, "%24.16e ", r);
+    for (int l = 0; l < ChannelPotentials.size(); l++)
+      fprintf(fout, "%24.16e ", ChannelPotentials[l].Vl(r)); // /r);
+    fprintf(fout, "\n");
   }
-  fclose (fout);
+  fclose(fout);
 
-  fout = fopen ("ul.dat", "w");
-  for (int i=1; i<PotentialGrid.NumPoints(); i++) {
-    double r= PotentialGrid[i];
-    fprintf (fout, "%24.16e ", r);
-    for (int l=0; l<ChannelPotentials.size(); l++)
-      fprintf (fout, "%24.16e ", ChannelPotentials[l].ul(r));// /r);
-    fprintf (fout, "\n");
+  fout = fopen("ul.dat", "w");
+  for (int i = 1; i < PotentialGrid.NumPoints(); i++)
+  {
+    double r = PotentialGrid[i];
+    fprintf(fout, "%24.16e ", r);
+    for (int l = 0; l < ChannelPotentials.size(); l++)
+      fprintf(fout, "%24.16e ", ChannelPotentials[l].ul(r)); // /r);
+    fprintf(fout, "\n");
   }
-  fclose (fout);
-
-
+  fclose(fout);
 }
 
-bool
-PseudoClass::ReadBFD_PP (std::string fileName)
+bool PseudoClass::ReadBFD_PP(std::string fileName)
 {
   MemParserClass parser;
-  assert(parser.OpenFile (fileName));
+  assert(parser.OpenFile(fileName));
 
-  assert (parser.FindToken ("Element Symbol:"));
+  assert(parser.FindToken("Element Symbol:"));
   std::string symbol;
-  assert (parser.ReadWord(symbol));
+  assert(parser.ReadWord(symbol));
   AtomicNumber = SymbolToZMap[symbol];
-  std::cerr << "Reading element " << symbol
-       << ", which has Z=" << AtomicNumber << std::endl;
+  std::cerr << "Reading element " << symbol << ", which has Z=" << AtomicNumber << std::endl;
   int numProtons, numProjectors;
-  assert (parser.FindToken ("Number of replaced protons:"));
-  assert (parser.ReadInt (numProtons));
-  assert (parser.FindToken ("Number of projectors:"));
-  assert (parser.ReadInt (numProjectors));
-  ChannelPotentials.resize(numProjectors+1);
-  assert (parser.FindToken ("Local component:"));
-  assert (parser.FindToken ("Exp."));
+  assert(parser.FindToken("Number of replaced protons:"));
+  assert(parser.ReadInt(numProtons));
+  assert(parser.FindToken("Number of projectors:"));
+  assert(parser.ReadInt(numProjectors));
+  ChannelPotentials.resize(numProjectors + 1);
+  assert(parser.FindToken("Local component:"));
+  assert(parser.FindToken("Exp."));
   double c0, c1, c2, exp0, exp1, exp2;
   int power;
-  assert (parser.ReadDouble(c0));
+  assert(parser.ReadDouble(c0));
   PseudoCharge = c0;
-  assert (parser.ReadInt (power));
-  assert (power == -1);
-  assert (parser.ReadDouble(exp0));
+  assert(parser.ReadInt(power));
+  assert(power == -1);
+  assert(parser.ReadDouble(exp0));
 
-  assert (parser.ReadDouble(c1));
-  assert (parser.ReadInt (power));
-  assert (power == 1);
-  assert (parser.ReadDouble(exp1));
+  assert(parser.ReadDouble(c1));
+  assert(parser.ReadInt(power));
+  assert(power == 1);
+  assert(parser.ReadDouble(exp1));
 
-  assert (parser.ReadDouble(c2));
-  assert (parser.ReadInt (power));
-  assert (power == 0);
-  assert (parser.ReadDouble(exp2));
+  assert(parser.ReadDouble(c2));
+  assert(parser.ReadInt(power));
+  assert(power == 0);
+  assert(parser.ReadDouble(exp2));
 
   // Create local channel spline
   std::vector<double> gridPoints, Vlocal, Vlocalr;
-  FILE *fout = fopen ("Vlocal.dat", "w");
-  for (double r=1.0e-8; r<150.0; r+=0.01) {
-    gridPoints.push_back (r);
-    double Vloc = (c0/r)*(expm1(-exp0*r*r)) +
-      c1*r*exp(-exp1*r*r) +
-      c2*exp(-exp2*r*r);
-    double Vlocr = (c0)*(expm1(-exp0*r*r)) +
-      c1*r*r*exp(-exp1*r*r) +
-      c2*r*exp(-exp2*r*r);
+  FILE* fout = fopen("Vlocal.dat", "w");
+  for (double r = 1.0e-8; r < 150.0; r += 0.01)
+  {
+    gridPoints.push_back(r);
+    double Vloc  = (c0 / r) * (expm1(-exp0 * r * r)) + c1 * r * exp(-exp1 * r * r) + c2 * exp(-exp2 * r * r);
+    double Vlocr = (c0) * (expm1(-exp0 * r * r)) + c1 * r * r * exp(-exp1 * r * r) + c2 * r * exp(-exp2 * r * r);
     Vlocal.push_back(Vloc);
     Vlocalr.push_back(Vlocr);
-    fprintf (fout, "%1.16e %1.16e %1.16e\n", r, Vloc, Vlocr);
+    fprintf(fout, "%1.16e %1.16e %1.16e\n", r, Vloc, Vlocr);
   }
-  fclose (fout);
+  fclose(fout);
   int local = numProjectors;
-  if (LocalChannel<0) LocalChannel = local;
-  PotentialGrid.Init (gridPoints);
+  if (LocalChannel < 0)
+    LocalChannel = local;
+  PotentialGrid.Init(gridPoints);
   ChannelPotentials[local].Vl.Init(PotentialGrid, Vlocal);
   ChannelPotentials[local].Vlr.Init(PotentialGrid, Vlocalr);
   ChannelPotentials[local].l = local;
 
   // Now read nonlocal component
-  assert (parser.FindToken ("Non-local component:"));
-  assert (parser.FindToken ("Proj."));
-  for (int l=0; l<numProjectors; l++) {
+  assert(parser.FindToken("Non-local component:"));
+  assert(parser.FindToken("Proj."));
+  for (int l = 0; l < numProjectors; l++)
+  {
     char fname[100];
-    snprintf (fname, 100, "V_%d.dat", l);
-    FILE *fout = fopen (fname, "w");
+    snprintf(fname, 100, "V_%d.dat", l);
+    FILE* fout = fopen(fname, "w");
     double c0, exp0;
     int power, channel;
-    assert (parser.ReadDouble (c0));
-    assert (parser.ReadInt (power));
-    assert (power == 0);
-    assert (parser.ReadDouble (exp0));
-    assert (parser.FindToken ("|"));
-    assert (parser.ReadInt(channel));
-    assert (channel == l);
-    assert (parser.FindToken("|"));
+    assert(parser.ReadDouble(c0));
+    assert(parser.ReadInt(power));
+    assert(power == 0);
+    assert(parser.ReadDouble(exp0));
+    assert(parser.FindToken("|"));
+    assert(parser.ReadInt(channel));
+    assert(channel == l);
+    assert(parser.FindToken("|"));
     std::vector<double> Vl(gridPoints.size()), Vlr(gridPoints.size());
-    for (int i=0; i<gridPoints.size(); i++) {
+    for (int i = 0; i < gridPoints.size(); i++)
+    {
       double r = gridPoints[i];
-      Vl[i]  =  Vlocal[i] +   c0*exp(-exp0*r*r);
-      Vlr[i] = Vlocalr[i] + r*c0*exp(-exp0*r*r);
-      fprintf (fout, "%1.16e %1.16e %1.16e\n", r, Vl[i], Vlr[i]);
+      Vl[i]    = Vlocal[i] + c0 * exp(-exp0 * r * r);
+      Vlr[i]   = Vlocalr[i] + r * c0 * exp(-exp0 * r * r);
+      fprintf(fout, "%1.16e %1.16e %1.16e\n", r, Vl[i], Vlr[i]);
     }
-    fclose (fout);
-    ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
-    ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
+    fclose(fout);
+    ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
+    ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
     ChannelPotentials[l].l = l;
   }
 
@@ -1079,93 +1152,98 @@ PseudoClass::ReadBFD_PP (std::string fileName)
 }
 
 
-bool
-PseudoClass::ReadFHI_PP (std::string fileName)
+bool PseudoClass::ReadFHI_PP(std::string fileName)
 {
   MemParserClass parser;
-  if (!parser.OpenFile (fileName)) {
+  if (!parser.OpenFile(fileName))
+  {
     std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
   std::string temp;
   // Read top comment line
-  assert (parser.ReadLine(temp));
+  assert(parser.ReadLine(temp));
   double atomCharge;
-  assert (parser.ReadDouble(atomCharge));
+  assert(parser.ReadDouble(atomCharge));
   AtomicNumber = (int)round(atomCharge);
-  assert (parser.ReadDouble(PseudoCharge));
+  assert(parser.ReadDouble(PseudoCharge));
   int date, pspcode, pspxc, lmax, lloc, mmax;
-  assert (parser.ReadInt(date));
-  assert (parser.ReadLine(temp));
-  assert (parser.ReadInt(pspcode));
-  assert (parser.ReadInt(pspxc));
-  assert (parser.ReadInt(lmax));
-  assert (parser.ReadInt(LocalChannel));
-  assert (parser.ReadInt(mmax));
+  assert(parser.ReadInt(date));
+  assert(parser.ReadLine(temp));
+  assert(parser.ReadInt(pspcode));
+  assert(parser.ReadInt(pspxc));
+  assert(parser.ReadInt(lmax));
+  assert(parser.ReadInt(LocalChannel));
+  assert(parser.ReadInt(mmax));
   // Read the rest of the line and skip the next 4
-  for (int i=0; i<5; i++)
-    assert (parser.FindToken("\n"));
+  for (int i = 0; i < 5; i++)
+    assert(parser.FindToken("\n"));
   // Now we are in the FHI file proper
   double chrg;
-  assert (parser.ReadDouble(chrg));
-  if(fabs(chrg-PseudoCharge) > 1.0e-10) {
+  assert(parser.ReadDouble(chrg));
+  if (fabs(chrg - PseudoCharge) > 1.0e-10)
+  {
     std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
     std::cerr << "chrg = " << chrg << std::endl;
   }
 
   // Read number of channels and resize
   int numChannels;
-  assert (parser.ReadInt(numChannels));
+  assert(parser.ReadInt(numChannels));
   ChannelPotentials.resize(numChannels);
 
   // Skip the next 10 lines
-  for (int i=0; i<11; i++)
-    assert (parser.FindToken("\n"));
+  for (int i = 0; i < 11; i++)
+    assert(parser.FindToken("\n"));
 
   // Read the number of grid points
-  for (int l=0; l<numChannels; l++) {
+  for (int l = 0; l < numChannels; l++)
+  {
     int numPoints;
     double a_ratio;
-    assert (parser.ReadInt(numPoints));
-    assert (parser.ReadDouble(a_ratio));
-    std::vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
-      Vlr(numPoints);
-    for (int m=0; m<numPoints; m++) {
+    assert(parser.ReadInt(numPoints));
+    assert(parser.ReadDouble(a_ratio));
+    std::vector<double> points(numPoints), ul(numPoints), Vl(numPoints), Vlr(numPoints);
+    for (int m = 0; m < numPoints; m++)
+    {
       int mtest;
-      assert (parser.ReadInt(mtest));
-      assert (mtest == (m+1));
-      assert (parser.ReadDouble(points[m]));
-      assert (parser.ReadDouble(ul[m]));
-      assert (parser.ReadDouble(Vl[m]));
-      Vlr[m] = Vl[m]*points[m];
+      assert(parser.ReadInt(mtest));
+      assert(mtest == (m + 1));
+      assert(parser.ReadDouble(points[m]));
+      assert(parser.ReadDouble(ul[m]));
+      assert(parser.ReadDouble(Vl[m]));
+      Vlr[m] = Vl[m] * points[m];
     }
-    PotentialGrid.Init (points);
-    ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
-    ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
-    ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
-    ChannelPotentials[l].l = l;
-    ChannelPotentials[l].n_principal = -1;
-    ChannelPotentials[l].Cutoff = 0.0;
+    PotentialGrid.Init(points);
+    ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
+    ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
+    ChannelPotentials[l].ul.Init(PotentialGrid, ul);
+    ChannelPotentials[l].l            = l;
+    ChannelPotentials[l].n_principal  = -1;
+    ChannelPotentials[l].Cutoff       = 0.0;
     ChannelPotentials[l].HasProjector = true;
   }
   // Now, figure out what rcut should be
   double rmax = PotentialGrid.End();
-  int n = PotentialGrid.NumPoints()-1;
-  bool diff = false;
-  while ((n>0) && !diff) {
+  int n       = PotentialGrid.NumPoints() - 1;
+  bool diff   = false;
+  while ((n > 0) && !diff)
+  {
     double r = PotentialGrid[n];
-    rmax = r;
-    for (int l1=0; l1<numChannels; l1++) {
+    rmax     = r;
+    for (int l1 = 0; l1 < numChannels; l1++)
+    {
       double Vl1 = ChannelPotentials[l1].Vl(r);
-      for (int l2=l1+1; l2<numChannels; l2++) {
-	double Vl2 = ChannelPotentials[l2].Vl(r);
-	if (fabs(Vl1-Vl2) > 1.0e-5)
-	  diff = true;
+      for (int l2 = l1 + 1; l2 < numChannels; l2++)
+      {
+        double Vl2 = ChannelPotentials[l2].Vl(r);
+        if (fabs(Vl1 - Vl2) > 1.0e-5)
+          diff = true;
       }
     }
     n--;
   }
-  for (int l=0; l<ChannelPotentials.size(); l++)
+  for (int l = 0; l < ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rmax;
 
   parser.CloseFile();
@@ -1178,41 +1256,42 @@ public:
   int l;
   std::vector<double> beta, u, V;
   KBprojector() {}
-  KBprojector(int l_, std::vector<double> beta_) :
-    l(l_), beta(beta_) {}
+  KBprojector(int l_, std::vector<double> beta_) : l(l_), beta(beta_) {}
 };
 
-bool
-PseudoClass::ReadUPF_PP (std::string fileName)
+bool PseudoClass::ReadUPF_PP(std::string fileName)
 {
   MemParserClass parser;
-  if (!parser.OpenFile (fileName)) {
+  if (!parser.OpenFile(fileName))
+  {
     std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
   std::string temp;
 
-  assert(parser.FindToken("<PP_HEADER>")); assert(parser.NextLine());
+  assert(parser.FindToken("<PP_HEADER>"));
+  assert(parser.NextLine());
   // Skip version number
   assert(parser.NextLine());
   std::string element, ppType, coreCorrection;
-  assert(parser.ReadWord(element));  assert(parser.NextLine());
+  assert(parser.ReadWord(element));
+  assert(parser.NextLine());
   assert(SymbolToZMap.find(element) != SymbolToZMap.end());
   AtomicNumber = SymbolToZMap[element];
   //  cerr << "Element = \"" << element << "\"\n";
 
   assert(parser.ReadWord(ppType));
-  if (ppType != "NC") {
-    std::cerr << "Psuedopotential type \"" << ppType
-	 << "\" is not norm-conserving.\n";
+  if (ppType != "NC")
+  {
+    std::cerr << "Psuedopotential type \"" << ppType << "\" is not norm-conserving.\n";
     abort();
   }
-  assert (parser.NextLine());
-  assert (parser.ReadWord(coreCorrection)); assert(parser.NextLine());
-  if (coreCorrection != "F" && coreCorrection != "f" &&
-      coreCorrection != "false" && coreCorrection != "False" &&
-      coreCorrection != ".F." && coreCorrection != ".f" &&
-      coreCorrection != "FALSE") {
+  assert(parser.NextLine());
+  assert(parser.ReadWord(coreCorrection));
+  assert(parser.NextLine());
+  if (coreCorrection != "F" && coreCorrection != "f" && coreCorrection != "false" && coreCorrection != "False" &&
+      coreCorrection != ".F." && coreCorrection != ".f" && coreCorrection != "FALSE")
+  {
     std::cerr << "It appears that a nonlinear core correction was used.  Cannot convert PP.\n";
     abort();
   }
@@ -1230,42 +1309,45 @@ PseudoClass::ReadUPF_PP (std::string fileName)
   assert(parser.NextLine());
 
   int numPoints;
-  assert(parser.ReadInt(numPoints)); assert(parser.NextLine());
+  assert(parser.ReadInt(numPoints));
+  assert(parser.NextLine());
   int numWF, numProj;
-  assert (parser.ReadInt(numWF)); assert(parser.ReadInt(numProj));
-  int numChannels = numProj+1;
+  assert(parser.ReadInt(numWF));
+  assert(parser.ReadInt(numProj));
+  int numChannels = numProj + 1;
 
   ChannelPotentials.resize(numChannels);
 
 
   assert(parser.FindToken("Wavefunctions"));
-//   for (int i=0; i<numWF; i++) {
-//     assert(parser.FindToken("NL"));
-//     int l;
-//     double occ;
-//     assert(parser.ReadInt(l));
-//     assert(parser.ReadDouble(occ));
-//   }
+  //   for (int i=0; i<numWF; i++) {
+  //     assert(parser.FindToken("NL"));
+  //     int l;
+  //     double occ;
+  //     assert(parser.ReadInt(l));
+  //     assert(parser.ReadDouble(occ));
+  //   }
   assert(parser.FindToken("</PP_HEADER>"));
 
   assert(parser.FindToken("<PP_MESH>"));
   assert(parser.FindToken("<PP_R>"));
   std::vector<double> r(numPoints), dr(numPoints);
-  for (int i=0; i<numPoints; i++)
+  for (int i = 0; i < numPoints; i++)
     assert(parser.ReadDouble(r[i]));
   assert(parser.FindToken("</PP_R>"));
   PotentialGrid.Init(r);
 
 
   assert(parser.FindToken("<PP_RAB>"));
-  for (int i=0; i<numPoints; i++)
+  for (int i = 0; i < numPoints; i++)
     assert(parser.ReadDouble(dr[i]));
   assert(parser.FindToken("</PP_RAB>"));
   assert(parser.FindToken("</PP_MESH>"));
 
   assert(parser.FindToken("<PP_LOCAL>"));
   std::vector<double> Vlocal(numPoints);
-  for (int i=0; i<numPoints; i++) {
+  for (int i = 0; i < numPoints; i++)
+  {
     assert(parser.ReadDouble(Vlocal[i]));
     Vlocal[i] *= 0.5;
   }
@@ -1275,232 +1357,245 @@ PseudoClass::ReadUPF_PP (std::string fileName)
 
   // Store which channels have nonlocal projectors:
   // Input:  l    Output:  index of projector
-  std::map<int,int> lmap;
+  std::map<int, int> lmap;
   std::vector<KBprojector> projectors;
-  for (int proj=0; proj<numProj; proj++) {
-    assert (parser.FindToken("<PP_BETA>"));
+  for (int proj = 0; proj < numProj; proj++)
+  {
+    assert(parser.FindToken("<PP_BETA>"));
     int Beta;
-    assert (parser.ReadInt(Beta));
-    assert(Beta == (proj+1));
+    assert(parser.ReadInt(Beta));
+    assert(Beta == (proj + 1));
     int l;
-    assert (parser.ReadInt(l));    parser.NextLine();
+    assert(parser.ReadInt(l));
+    parser.NextLine();
     lmap[l] = proj;
     //    fprintf (stderr, "Found a projector for l=%d\n", l);
 
     int npt;
-    assert (parser.ReadInt(npt));
+    assert(parser.ReadInt(npt));
 
     std::vector<double> beta(numPoints);
-    for (int ir=0; ir<numPoints; ir++)
+    for (int ir = 0; ir < numPoints; ir++)
       assert(parser.ReadDouble(beta[ir]));
-    assert (parser.FindToken("</PP_BETA>"));
+    assert(parser.FindToken("</PP_BETA>"));
 
     projectors.push_back(KBprojector(l, beta));
   }
   assert(parser.FindToken("</PP_NONLOCAL>"));
 
-  int llocal=0;
-  while (lmap.find(llocal) != lmap.end()) llocal++;
+  int llocal = 0;
+  while (lmap.find(llocal) != lmap.end())
+    llocal++;
   LocalChannel = llocal;
   //  fprintf (stderr, "First channel without a projector=%d\n", llocal);
   ChannelPotentials[llocal].Vl.Init(PotentialGrid, Vlocal);
   std::vector<double> Vlocal_r(numPoints);
-  for (int ir=0; ir<numPoints; ir++)
-    Vlocal_r[ir] = r[ir]*Vlocal[ir];
+  for (int ir = 0; ir < numPoints; ir++)
+    Vlocal_r[ir] = r[ir] * Vlocal[ir];
   ChannelPotentials[llocal].Vlr.Init(PotentialGrid, Vlocal_r);
   ChannelPotentials[llocal].l = llocal;
 
-  if (numWF) {
-    assert (parser.FindToken("PP_PSWFC"));
-    assert (parser.NextLine());
-    for (int iwf=0; iwf<numWF; iwf++) {
+  if (numWF)
+  {
+    assert(parser.FindToken("PP_PSWFC"));
+    assert(parser.NextLine());
+    for (int iwf = 0; iwf < numWF; iwf++)
+    {
       std::string NL;
-      assert (parser.ReadWord(NL));
+      assert(parser.ReadWord(NL));
       int l;
-      assert (parser.ReadInt(l));
+      assert(parser.ReadInt(l));
       double occ;
-      assert (parser.ReadDouble(occ));
+      assert(parser.ReadDouble(occ));
       parser.NextLine();
       std::vector<double> wf(numPoints);
-      for (int ir=0; ir<numPoints; ir++)
-	assert (parser.ReadDouble(wf[ir]));
+      for (int ir = 0; ir < numPoints; ir++)
+        assert(parser.ReadDouble(wf[ir]));
       // Now, setup the channel potentials
-      if (l != llocal) {
-	assert (lmap.find(l) != lmap.end());
-	KBprojector &proj = projectors[lmap[l]];
-	std::vector<double> Vl(numPoints), Vlr(numPoints);
-	for (int ir=0; ir<numPoints; ir++) {
-	  Vl[ir]  = Vlocal[ir];
-	  if (wf[ir] != 0.0)
-	    Vl[ir] += proj.beta[ir]/(2.0*wf[ir]);
-	  Vlr[ir] = r[ir]*Vl[ir];
-	}
-	Vl[0] = 2.0*Vl[1] - Vl[2];
-	Vlr[0] = r[0] * Vl[0];
+      if (l != llocal)
+      {
+        assert(lmap.find(l) != lmap.end());
+        KBprojector& proj = projectors[lmap[l]];
+        std::vector<double> Vl(numPoints), Vlr(numPoints);
+        for (int ir = 0; ir < numPoints; ir++)
+        {
+          Vl[ir] = Vlocal[ir];
+          if (wf[ir] != 0.0)
+            Vl[ir] += proj.beta[ir] / (2.0 * wf[ir]);
+          Vlr[ir] = r[ir] * Vl[ir];
+        }
+        Vl[0]  = 2.0 * Vl[1] - Vl[2];
+        Vlr[0] = r[0] * Vl[0];
 
-// 	for (int ir=0; ir<numPoints; ir++)
-// 	  fprintf (stderr, "Vl(%8.3f) = %22.16f\n", r[ir], Vl[ir]);
+        // 	for (int ir=0; ir<numPoints; ir++)
+        // 	  fprintf (stderr, "Vl(%8.3f) = %22.16f\n", r[ir], Vl[ir]);
 
-	ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
-	ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
-	ChannelPotentials[l].l = l;
+        ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
+        ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
+        ChannelPotentials[l].l = l;
       }
       ChannelPotentials[l].ul.Init(PotentialGrid, wf);
-      ChannelPotentials[l].Occupation = occ;
+      ChannelPotentials[l].Occupation   = occ;
       ChannelPotentials[l].HasProjector = true;
     }
 
-    assert (parser.FindToken("/PP_PSWFC"));
+    assert(parser.FindToken("/PP_PSWFC"));
   }
 
   // Now, figure out what rcut should be
   double rmax = PotentialGrid.End();
-  int n = PotentialGrid.NumPoints()-1;
-  bool diff = false;
-  while ((n>0) && !diff) {
+  int n       = PotentialGrid.NumPoints() - 1;
+  bool diff   = false;
+  while ((n > 0) && !diff)
+  {
     double r = PotentialGrid[n];
-    rmax = r;
-    for (int l1=0; l1<numChannels; l1++) {
+    rmax     = r;
+    for (int l1 = 0; l1 < numChannels; l1++)
+    {
       double Vl1 = ChannelPotentials[l1].Vl(r);
-      for (int l2=l1+1; l2<numChannels; l2++) {
-	double Vl2 = ChannelPotentials[l2].Vl(r);
-	if (fabs(Vl1-Vl2) > 1.0e-5)
-	  diff = true;
+      for (int l2 = l1 + 1; l2 < numChannels; l2++)
+      {
+        double Vl2 = ChannelPotentials[l2].Vl(r);
+        if (fabs(Vl1 - Vl2) > 1.0e-5)
+          diff = true;
       }
     }
     n--;
   }
-  fprintf (stderr, "rmax = %1.5f  numChannels = %d\n", rmax, numChannels);
-  for (int l=0; l<ChannelPotentials.size(); l++)
+  fprintf(stderr, "rmax = %1.5f  numChannels = %d\n", rmax, numChannels);
+  for (int l = 0; l < ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rmax;
 
   parser.CloseFile();
 
   // Read top comment line
-//   assert (parser.ReadLine(temp));
-//   double atomCharge;
-//   assert (parser.ReadDouble(atomCharge));
-//   AtomicNumber = (int)round(atomCharge);
-//   assert (parser.ReadDouble(PseudoCharge));
-//   int date, pspcode, pspxc, lmax, lloc, mmax;
-//   assert (parser.ReadInt(date));
-//   assert (parser.ReadLine(temp));
-//   assert (parser.ReadInt(pspcode));
-//   assert (parser.ReadInt(pspxc));
-//   assert (parser.ReadInt(lmax));
-//   assert (parser.ReadInt(LocalChannel));
-//   assert (parser.ReadInt(mmax));
-//   // Read the rest of the line and skip the next 4
-//   for (int i=0; i<5; i++)
-//     assert (parser.FindToken("\n"));
-//   // Now we are in the FHI file proper
-//   double chrg;
-//   assert (parser.ReadDouble(chrg));
-//   if(fabs(chrg-PseudoCharge) > 1.0e-10) {
-//     cerr << "PseudoCharge = " << PseudoCharge << endl;
-//     cerr << "chrg = " << chrg << endl;
-//   }
+  //   assert (parser.ReadLine(temp));
+  //   double atomCharge;
+  //   assert (parser.ReadDouble(atomCharge));
+  //   AtomicNumber = (int)round(atomCharge);
+  //   assert (parser.ReadDouble(PseudoCharge));
+  //   int date, pspcode, pspxc, lmax, lloc, mmax;
+  //   assert (parser.ReadInt(date));
+  //   assert (parser.ReadLine(temp));
+  //   assert (parser.ReadInt(pspcode));
+  //   assert (parser.ReadInt(pspxc));
+  //   assert (parser.ReadInt(lmax));
+  //   assert (parser.ReadInt(LocalChannel));
+  //   assert (parser.ReadInt(mmax));
+  //   // Read the rest of the line and skip the next 4
+  //   for (int i=0; i<5; i++)
+  //     assert (parser.FindToken("\n"));
+  //   // Now we are in the FHI file proper
+  //   double chrg;
+  //   assert (parser.ReadDouble(chrg));
+  //   if(fabs(chrg-PseudoCharge) > 1.0e-10) {
+  //     cerr << "PseudoCharge = " << PseudoCharge << endl;
+  //     cerr << "chrg = " << chrg << endl;
+  //   }
 
-//   // Read number of channels and resize
-//   int numChannels;
-//   assert (parser.ReadInt(numChannels));
-//   ChannelPotentials.resize(numChannels);
+  //   // Read number of channels and resize
+  //   int numChannels;
+  //   assert (parser.ReadInt(numChannels));
+  //   ChannelPotentials.resize(numChannels);
 
-//   // Skip the next 10 lines
-//   for (int i=0; i<11; i++)
-//     assert (parser.FindToken("\n"));
+  //   // Skip the next 10 lines
+  //   for (int i=0; i<11; i++)
+  //     assert (parser.FindToken("\n"));
 
-//   // Read the number of grid points
-//   for (int l=0; l<numChannels; l++) {
-//     int numPoints;
-//     double a_ratio;
-//     assert (parser.ReadInt(numPoints));
-//     assert (parser.ReadDouble(a_ratio));
-//     vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
-//       Vlr(numPoints);
-//     for (int m=0; m<numPoints; m++) {
-//       int mtest;
-//       assert (parser.ReadInt(mtest));
-//       assert (mtest == (m+1));
-//       assert (parser.ReadDouble(points[m]));
-//       assert (parser.ReadDouble(ul[m]));
-//       assert (parser.ReadDouble(Vl[m]));
-//       Vlr[m] = Vl[m]*points[m];
-//     }
-//     PotentialGrid.Init (points);
-//     ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
-//     ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
-//     ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
-//     ChannelPotentials[l].l = l;
-//     ChannelPotentials[l].n_principal = -1;
-//     ChannelPotentials[l].Cutoff = 0.0;
-//     ChannelPotentials[l].HasProjector = true;
-//   }
-//   // Now, figure out what rcut should be
-//   double rmax = PotentialGrid.End();
-//   int n = PotentialGrid.NumPoints()-1;
-//   bool diff = false;
-//   while ((n>0) && !diff) {
-//     double r = PotentialGrid[n];
-//     rmax = r;
-//     for (int l1=0; l1<numChannels; l1++) {
-//       double Vl1 = ChannelPotentials[l1].Vl(r);
-//       for (int l2=l1+1; l2<numChannels; l2++) {
-// 	double Vl2 = ChannelPotentials[l2].Vl(r);
-// 	if (fabs(Vl1-Vl2) > 1.0e-5)
-// 	  diff = true;
-//       }
-//     }
-//     n--;
-//   }
-//   for (int l=0; l<ChannelPotentials.size(); l++)
-//     ChannelPotentials[l].Cutoff = rmax;
+  //   // Read the number of grid points
+  //   for (int l=0; l<numChannels; l++) {
+  //     int numPoints;
+  //     double a_ratio;
+  //     assert (parser.ReadInt(numPoints));
+  //     assert (parser.ReadDouble(a_ratio));
+  //     vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
+  //       Vlr(numPoints);
+  //     for (int m=0; m<numPoints; m++) {
+  //       int mtest;
+  //       assert (parser.ReadInt(mtest));
+  //       assert (mtest == (m+1));
+  //       assert (parser.ReadDouble(points[m]));
+  //       assert (parser.ReadDouble(ul[m]));
+  //       assert (parser.ReadDouble(Vl[m]));
+  //       Vlr[m] = Vl[m]*points[m];
+  //     }
+  //     PotentialGrid.Init (points);
+  //     ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
+  //     ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
+  //     ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
+  //     ChannelPotentials[l].l = l;
+  //     ChannelPotentials[l].n_principal = -1;
+  //     ChannelPotentials[l].Cutoff = 0.0;
+  //     ChannelPotentials[l].HasProjector = true;
+  //   }
+  //   // Now, figure out what rcut should be
+  //   double rmax = PotentialGrid.End();
+  //   int n = PotentialGrid.NumPoints()-1;
+  //   bool diff = false;
+  //   while ((n>0) && !diff) {
+  //     double r = PotentialGrid[n];
+  //     rmax = r;
+  //     for (int l1=0; l1<numChannels; l1++) {
+  //       double Vl1 = ChannelPotentials[l1].Vl(r);
+  //       for (int l2=l1+1; l2<numChannels; l2++) {
+  // 	double Vl2 = ChannelPotentials[l2].Vl(r);
+  // 	if (fabs(Vl1-Vl2) > 1.0e-5)
+  // 	  diff = true;
+  //       }
+  //     }
+  //     n--;
+  //   }
+  //   for (int l=0; l<ChannelPotentials.size(); l++)
+  //     ChannelPotentials[l].Cutoff = rmax;
 
-//   parser.CloseFile();
-   return true;
+  //   parser.CloseFile();
+  return true;
 }
 
-bool
-PseudoClass::ReadGAMESS_PP (std::string fileName)
+bool PseudoClass::ReadGAMESS_PP(std::string fileName)
 {
   MemParserClass parser;
-  assert (parser.OpenFile (fileName));
+  assert(parser.OpenFile(fileName));
 
   std::string psp_name, psp_type;
-  assert (parser.ReadWord(psp_name));
-  assert (parser.ReadWord(psp_type));
+  assert(parser.ReadWord(psp_name));
+  assert(parser.ReadWord(psp_type));
   // izcore is the number of core electrons removed
   // Find atomic number.
   std::string symbol;
-  int i=0;
-  while ((i<psp_name.size()) && (psp_name[i] != '-')) {
+  int i = 0;
+  while ((i < psp_name.size()) && (psp_name[i] != '-'))
+  {
     symbol = symbol + psp_name[i];
     i++;
   }
   std::cerr << "Atomic symbol = " << symbol << std::endl;
-  int Z = SymbolToZMap[symbol];
+  int Z        = SymbolToZMap[symbol];
   AtomicNumber = Z;
   int izcore, lmax;
-  assert (parser.ReadInt(izcore));
-  PseudoCharge = (double)(Z-izcore);
-  assert (parser.ReadInt(lmax));
-  assert (parser.FindToken("\n"));
-  if (LocalChannel<0) LocalChannel = lmax;
+  assert(parser.ReadInt(izcore));
+  PseudoCharge = (double)(Z - izcore);
+  assert(parser.ReadInt(lmax));
+  assert(parser.FindToken("\n"));
+  if (LocalChannel < 0)
+    LocalChannel = lmax;
 
-  ChannelPotentials.resize(lmax+1);
+  ChannelPotentials.resize(lmax + 1);
 
   // Setup the potential grid
   std::vector<double> rPoints;
-  if (WriteLogGrid) {
+  if (WriteLogGrid)
+  {
     const int numPoints = 2001;
-    double end = 150.0;
-    double step  = 0.00625;
-    double scale = end/(expm1(step*(numPoints-1)));
-    for (int i=1; i<numPoints; i++)
-      rPoints.push_back(scale * (expm1(step*i)));
+    double end          = 150.0;
+    double step         = 0.00625;
+    double scale        = end / (expm1(step * (numPoints - 1)));
+    for (int i = 1; i < numPoints; i++)
+      rPoints.push_back(scale * (expm1(step * i)));
   }
-  else {
-    for (double r=1.0e-10; r<=150.00001; r+=0.005)
+  else
+  {
+    for (double r = 1.0e-10; r <= 150.00001; r += 0.005)
       rPoints.push_back(r);
   }
   PotentialGrid.Init(rPoints);
@@ -1510,74 +1605,82 @@ PseudoClass::ReadGAMESS_PP (std::string fileName)
   std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
   std::cerr << "lmax = " << lmax << std::endl;
 
-  for (int index=0; index<=lmax; index++) {
+  for (int index = 0; index <= lmax; index++)
+  {
     // lmax is first, followed by 0, 1, etc.
-    int l = (index+lmax)%(lmax+1);
+    int l = (index + lmax) % (lmax + 1);
     int ngpot;
-    assert (parser.ReadInt (ngpot));
-    assert (parser.FindToken("\n"));
+    assert(parser.ReadInt(ngpot));
+    assert(parser.FindToken("\n"));
     std::vector<double> coefs(ngpot), exponents(ngpot);
     std::vector<int> powers(ngpot);
 
     // The local channel is given first
-    for (int i=0; i<ngpot; i++) {
-      assert (parser.ReadDouble(    coefs[i]));
-      assert (parser.ReadInt(      powers[i]));
-      assert (parser.ReadDouble(exponents[i]));
-      assert (parser.FindToken ("\n"));
+    for (int i = 0; i < ngpot; i++)
+    {
+      assert(parser.ReadDouble(coefs[i]));
+      assert(parser.ReadInt(powers[i]));
+      assert(parser.ReadDouble(exponents[i]));
+      assert(parser.FindToken("\n"));
     }
     // Now, setup potentials
-    if (index == 0) {
-      for (int n=0; n<N; n++) {
-	double r = rPoints[n];
-	double val = 0.0;
-	for (int i=0; i<ngpot; i++)
-	  val += coefs[i] * pow(r,(double)(powers[i]-2))
-	    * exp(-exponents[i]*r*r);
-	Vlocal[n]   =   val -(double)PseudoCharge/r;
-	Vlocal_r[n] = r*val - (double)PseudoCharge;
+    if (index == 0)
+    {
+      for (int n = 0; n < N; n++)
+      {
+        double r   = rPoints[n];
+        double val = 0.0;
+        for (int i = 0; i < ngpot; i++)
+          val += coefs[i] * pow(r, (double)(powers[i] - 2)) * exp(-exponents[i] * r * r);
+        Vlocal[n]   = val - (double)PseudoCharge / r;
+        Vlocal_r[n] = r * val - (double)PseudoCharge;
       }
       ChannelPotentials[l].l = l;
-      ChannelPotentials[l].Vl.Init (PotentialGrid, Vlocal);
-      ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlocal_r);
+      ChannelPotentials[l].Vl.Init(PotentialGrid, Vlocal);
+      ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlocal_r);
     }
-    else {
-      for (int n=0; n<N; n++) {
-	double r = rPoints[n];
-	double val = 0.0;
-	for (int i=0; i<ngpot; i++)
-	  val += coefs[i] * pow(r,(double)(powers[i]-2))
-	    * exp(-exponents[i]*r*r);
-	Vl[n]   = Vlocal[n] + val;
-	Vl_r[n] = Vlocal_r[n] + r*val;
+    else
+    {
+      for (int n = 0; n < N; n++)
+      {
+        double r   = rPoints[n];
+        double val = 0.0;
+        for (int i = 0; i < ngpot; i++)
+          val += coefs[i] * pow(r, (double)(powers[i] - 2)) * exp(-exponents[i] * r * r);
+        Vl[n]   = Vlocal[n] + val;
+        Vl_r[n] = Vlocal_r[n] + r * val;
       }
       ChannelPotentials[l].l = l;
-      ChannelPotentials[l].Vl.Init (PotentialGrid, Vl);
-      ChannelPotentials[l].Vlr.Init (PotentialGrid, Vl_r);
+      ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
+      ChannelPotentials[l].Vlr.Init(PotentialGrid, Vl_r);
     }
   }
   // Now, compute cutoff radius
-  bool done=false;
-  int ir = rPoints.size()-1;
-  if (ChannelPotentials.size() > 1) {
-    while (ir > 0 && !done) {
+  bool done = false;
+  int ir    = rPoints.size() - 1;
+  if (ChannelPotentials.size() > 1)
+  {
+    while (ir > 0 && !done)
+    {
       double vlocal = ChannelPotentials[LocalChannel].Vl(ir);
-      for (int l=0; l<ChannelPotentials.size(); l++)
-	if (ChannelPotentials[l].l != LocalChannel)
-	  if (fabs(ChannelPotentials[l].Vl(ir) - vlocal) > 1.0e-5)
-	    done = true;
+      for (int l = 0; l < ChannelPotentials.size(); l++)
+        if (ChannelPotentials[l].l != LocalChannel)
+          if (fabs(ChannelPotentials[l].Vl(ir) - vlocal) > 1.0e-5)
+            done = true;
       ir--;
     }
   }
-  else {
-    while (ir > 0 && !done) {
+  else
+  {
+    while (ir > 0 && !done)
+    {
       double vlocal = ChannelPotentials[LocalChannel].Vl(ir);
-      double r = rPoints[ir];
-      done = fabs (vlocal + PseudoCharge/r) > 1.0e-5;
+      double r      = rPoints[ir];
+      done          = fabs(vlocal + PseudoCharge / r) > 1.0e-5;
       ir--;
     }
   }
-  for (int l=0; l<ChannelPotentials.size(); l++)
+  for (int l = 0; l < ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rPoints[ir];
 
 
@@ -1585,26 +1688,24 @@ PseudoClass::ReadGAMESS_PP (std::string fileName)
   return true;
 }
 
-bool
-ReadInt (std::string &s, int &n)
+bool ReadInt(std::string& s, int& n)
 {
-  int pos=0;
+  int pos = 0;
   std::string sint;
   while (s[pos] >= '0' && s[pos] <= '9')
     sint.push_back(s[pos++]);
-  s.erase(0,pos);
-  n = atoi (sint.c_str());
+  s.erase(0, pos);
+  n = atoi(sint.c_str());
   return true;
 }
 
-bool
-ReadDouble (std::string &s, double &x)
+bool ReadDouble(std::string& s, double& x)
 {
-  int pos=0;
+  int pos = 0;
   std::string sd;
-  while ((s[pos] >= '0' && s[pos] <= '9') || s[pos]=='.')
+  while ((s[pos] >= '0' && s[pos] <= '9') || s[pos] == '.')
     sd.push_back(s[pos++]);
-  s.erase(0,pos);
+  s.erase(0, pos);
   x = strtod(sd.c_str(), (char**)NULL);
   return true;
 }
@@ -1617,161 +1718,169 @@ Config::Config(std::string s)
   ChannelRevMap['d'] = 2;
   ChannelRevMap['f'] = 3;
   ChannelRevMap['g'] = 4;
-  while (s.size() > 0) {
+  while (s.size() > 0)
+  {
     int n, l;
     double occ;
-    ReadInt (s, n);
+    ReadInt(s, n);
     l = ChannelRevMap[s[0]];
-    s.erase(0,1);
-    assert (s[0] == '(');
-    s.erase(0,1);
-    ReadDouble (s, occ);
-    assert (s[0] == ')');
-    s.erase(0,1);
-    States.push_back (State(n,l,occ));
+    s.erase(0, 1);
+    assert(s[0] == '(');
+    s.erase(0, 1);
+    ReadDouble(s, occ);
+    assert(s[0] == ')');
+    s.erase(0, 1);
+    States.push_back(State(n, l, occ));
   }
 }
 
 
-
-bool
-PseudoClass::ReadCASINO_PP (std::string fileName)
+bool PseudoClass::ReadCASINO_PP(std::string fileName)
 {
   MemParserClass parser;
-  parser.OpenFile (fileName);
+  parser.OpenFile(fileName);
 
-  assert (parser.FindToken("pseudo-charge"));
-  assert (parser.ReadInt (AtomicNumber));
-  assert (parser.ReadDouble (PseudoCharge));
-  assert (parser.FindToken("(rydberg/hartree/ev)"));
-  assert (parser.FindToken("\n"));
-  assert (parser.ReadWord(EnergyUnit));
+  assert(parser.FindToken("pseudo-charge"));
+  assert(parser.ReadInt(AtomicNumber));
+  assert(parser.ReadDouble(PseudoCharge));
+  assert(parser.FindToken("(rydberg/hartree/ev)"));
+  assert(parser.FindToken("\n"));
+  assert(parser.ReadWord(EnergyUnit));
   std::cerr << "EnergyUnit = " << EnergyUnit << std::endl;
-  assert (parser.FindToken("(0=s,1=p,2=d..)"));
-  assert (parser.ReadInt (LocalChannel));
-  assert (parser.FindToken("grid points"));
+  assert(parser.FindToken("(0=s,1=p,2=d..)"));
+  assert(parser.ReadInt(LocalChannel));
+  assert(parser.FindToken("grid points"));
   int numGridPoints;
-  assert (parser.ReadInt(numGridPoints));
-  std::vector<double> gridPoints(numGridPoints), Vl(numGridPoints),
-    Vlr(numGridPoints);
-  assert (parser.FindToken ("in"));
-  assert (parser.ReadWord(LengthUnit));
+  assert(parser.ReadInt(numGridPoints));
+  std::vector<double> gridPoints(numGridPoints), Vl(numGridPoints), Vlr(numGridPoints);
+  assert(parser.FindToken("in"));
+  assert(parser.ReadWord(LengthUnit));
   std::cerr << "LengthUnit = " << LengthUnit << std::endl;
-  assert (parser.FindToken("\n"));
+  assert(parser.FindToken("\n"));
   //  assert (parser.FindToken("atomic units"));
-  for (int i=0; i<numGridPoints; i++) {
-    assert (parser.ReadDouble(gridPoints[i]));
-    gridPoints[i] *= UnitToBohrMap [LengthUnit];
+  for (int i = 0; i < numGridPoints; i++)
+  {
+    assert(parser.ReadDouble(gridPoints[i]));
+    gridPoints[i] *= UnitToBohrMap[LengthUnit];
   }
-  PotentialGrid.Init (gridPoints);
-  int l=0;
-  int numChannels=0;
+  PotentialGrid.Init(gridPoints);
+  int l           = 0;
+  int numChannels = 0;
   bool done(false);
-  while (!done) {
+  while (!done)
+  {
     if (!parser.FindToken("(L="))
       done = true;
-    else {
+    else
+    {
       numChannels++;
-      assert (parser.ReadInt(l));
-      assert (parser.FindToken("\n"));
-      for (int i=0; i<numGridPoints; i++) {
-      	assert (parser.ReadDouble(Vl[i]));
-      	Vl[i] *= UnitToHartreeMap[EnergyUnit];
-      	Vlr[i] = Vl[i];
-      	Vl[i] /= PotentialGrid[i];
+      assert(parser.ReadInt(l));
+      assert(parser.FindToken("\n"));
+      for (int i = 0; i < numGridPoints; i++)
+      {
+        assert(parser.ReadDouble(Vl[i]));
+        Vl[i] *= UnitToHartreeMap[EnergyUnit];
+        Vlr[i] = Vl[i];
+        Vl[i] /= PotentialGrid[i];
       }
-      Vl[0] = 2.0*Vl[1]-Vl[2];
+      Vl[0] = 2.0 * Vl[1] - Vl[2];
       ChannelPotentials.push_back(ChannelPotentialClass());
       ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
       ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
       ChannelPotentials[l].l = l;
     }
   }
-//  std::cerr << "Found " << (l+1) << " l-channel potentials.\n";
+  //  std::cerr << "Found " << (l+1) << " l-channel potentials.\n";
   std::cerr << "Found " << numChannels << " l-channel potentials.\n";
 
   // Now read the summary file to get core radii
-  if (parser.OpenFile ("summary.txt")) {
+  if (parser.OpenFile("summary.txt"))
+  {
     std::string summaryUnits;
-    assert (parser.FindToken("Units:"));
-    assert (parser.ReadWord (summaryUnits));
-    assert (parser.FindToken("core radii"));
-    assert (parser.FindToken("\n"));
-    assert (parser.FindToken("\n"));
+    assert(parser.FindToken("Units:"));
+    assert(parser.ReadWord(summaryUnits));
+    assert(parser.FindToken("core radii"));
+    assert(parser.FindToken("\n"));
+    assert(parser.FindToken("\n"));
     // Read core radii
     double rc;
-    for (int i=0; i<=l; i++) {
-      assert (parser.FindToken (ChannelMap[i]));
-      assert (parser.ReadDouble (rc));
+    for (int i = 0; i <= l; i++)
+    {
+      assert(parser.FindToken(ChannelMap[i]));
+      assert(parser.ReadDouble(rc));
       ChannelPotentials[i].Cutoff = rc;
     }
 
-    assert (parser.FindToken("r_loc"));
-    assert (parser.FindToken("\n"));
-    assert (parser.FindToken("\n"));
-    assert (parser.FindToken("(Grid)"));
+    assert(parser.FindToken("r_loc"));
+    assert(parser.FindToken("\n"));
+    assert(parser.FindToken("\n"));
+    assert(parser.FindToken("(Grid)"));
     double rloc;
-    assert (parser.ReadDouble(rloc));
+    assert(parser.ReadDouble(rloc));
 
     // Overwrite radius with localization radius
-    for (int i=0; i<=l; i++)
+    for (int i = 0; i <= l; i++)
       ChannelPotentials[i].Cutoff = rloc;
 
     // Find ground state occupations
-    assert (parser.FindToken ("Eigenvalues of the"));
+    assert(parser.FindToken("Eigenvalues of the"));
     std::string GSconfig;
-    parser.ReadWord (GSconfig);
+    parser.ReadWord(GSconfig);
     Config c(GSconfig);
-    for (int is=0; is<c.size(); is++)
+    for (int is = 0; is < c.size(); is++)
       ChannelPotentials[c[is].l].Occupation = c[is].occ;
 
     // Now read eigenvalues of ground state
-    assert (parser.FindToken ("Pseudo HF"));
-    assert (parser.FindToken ("\n"));
-    assert (parser.FindToken ("\n"));
+    assert(parser.FindToken("Pseudo HF"));
+    assert(parser.FindToken("\n"));
+    assert(parser.FindToken("\n"));
     std::string channel;
-    parser.ReadWord (channel);
-    while ((channel=="s") || (channel=="p") || (channel=="d") ||
-  	 (channel=="f") || (channel=="g")) {
+    parser.ReadWord(channel);
+    while ((channel == "s") || (channel == "p") || (channel == "d") || (channel == "f") || (channel == "g"))
+    {
       int l = ChannelRevMap[channel];
       std::string tmp;
-      parser.ReadWord (tmp);
-      assert (parser.ReadDouble (ChannelPotentials[l].Eigenvalue));
+      parser.ReadWord(tmp);
+      assert(parser.ReadDouble(ChannelPotentials[l].Eigenvalue));
       ChannelPotentials[l].Eigenvalue *= UnitToHartreeMap[summaryUnits];
-      std::cerr << "Eigenvalue for " << channel << "-channel = "
-  	 << ChannelPotentials[l].Eigenvalue << std::endl;
-      parser.ReadLine (tmp);
-      parser.ReadWord (channel);
+      std::cerr << "Eigenvalue for " << channel << "-channel = " << ChannelPotentials[l].Eigenvalue << std::endl;
+      parser.ReadLine(tmp);
+      parser.ReadWord(channel);
     }
     // Read total energy
-    assert (parser.FindToken ("total energy"));
-    assert (parser.FindToken ("="));
-    assert (parser.ReadDouble (TotalEnergy));
+    assert(parser.FindToken("total energy"));
+    assert(parser.FindToken("="));
+    assert(parser.ReadDouble(TotalEnergy));
     TotalEnergy *= UnitToHartreeMap[summaryUnits];
     std::cerr << "Total energy = " << TotalEnergy << std::endl;
-  } else {
+  }
+  else
+  {
     // Now, figure out what rcut should be
     double rmax = PotentialGrid.End();
-    int n = PotentialGrid.NumPoints()-1;
-    bool diff = false;
-    while ((n>0) && !diff) {
+    int n       = PotentialGrid.NumPoints() - 1;
+    bool diff   = false;
+    while ((n > 0) && !diff)
+    {
       double r = PotentialGrid[n];
-      rmax = r;
-      for (int l1=0; l1<numChannels; l1++) {
+      rmax     = r;
+      for (int l1 = 0; l1 < numChannels; l1++)
+      {
         double Vl1 = ChannelPotentials[l1].Vl(r);
-        for (int l2=l1+1; l2<numChannels; l2++) {
-    double Vl2 = ChannelPotentials[l2].Vl(r);
-    if (fabs(Vl1-Vl2) > 1.0e-6)
-      diff = true;
+        for (int l2 = l1 + 1; l2 < numChannels; l2++)
+        {
+          double Vl2 = ChannelPotentials[l2].Vl(r);
+          if (fabs(Vl1 - Vl2) > 1.0e-6)
+            diff = true;
         }
       }
       n--;
     }
-    for (int l=0; l<ChannelPotentials.size(); l++)
+    for (int l = 0; l < ChannelPotentials.size(); l++)
       ChannelPotentials[l].Cutoff = rmax;
   }
-//   for (int i=0; i<=l; i++)
-//     ChannelPotentials[i].Cutoff = rloc;
+  //   for (int i=0; i<=l; i++)
+  //     ChannelPotentials[i].Cutoff = rloc;
 
   return true;
 }
@@ -1779,104 +1888,104 @@ PseudoClass::ReadCASINO_PP (std::string fileName)
 
 /// Note:  the pseudopotentials must be read before the wave
 /// functions.
-bool
-PseudoClass::ReadCASINO_WF (std::string fileName, int l)
+bool PseudoClass::ReadCASINO_WF(std::string fileName, int l)
 {
   // Make sure that l is not too high
-  assert (l < ChannelPotentials.size());
+  assert(l < ChannelPotentials.size());
   MemParserClass parser;
-  parser.OpenFile (fileName);
+  parser.OpenFile(fileName);
 
   // Make sure this a wave function file
-  assert (parser.FindToken ("wave function"));
+  assert(parser.FindToken("wave function"));
   // Find atomic number
-  assert (parser.FindToken ("Atomic number"));
+  assert(parser.FindToken("Atomic number"));
   int atomicNumber;
-  assert (parser.ReadInt(atomicNumber));
-  assert (atomicNumber == AtomicNumber);
+  assert(parser.ReadInt(atomicNumber));
+  assert(atomicNumber == AtomicNumber);
   int numOrbitals;
-  assert (parser.FindToken("number of orbitals"));
-  assert (parser.ReadInt(numOrbitals));
-  assert (parser.FindToken("Radial grid"));
-  assert (parser.FindToken("\n"));
+  assert(parser.FindToken("number of orbitals"));
+  assert(parser.ReadInt(numOrbitals));
+  assert(parser.FindToken("Radial grid"));
+  assert(parser.FindToken("\n"));
   int numPoints;
-  assert (parser.ReadInt(numPoints));
-  assert (PotentialGrid.NumPoints() == numPoints);
+  assert(parser.ReadInt(numPoints));
+  assert(PotentialGrid.NumPoints() == numPoints);
   // Make sure we have the same grid as the potential file
-  for (int i=0; i<numPoints; i++) {
+  for (int i = 0; i < numPoints; i++)
+  {
     double r;
     assert(parser.ReadDouble(r));
-    assert (fabs(r-PotentialGrid[i]) < 1.0e-10);
+    assert(fabs(r - PotentialGrid[i]) < 1.0e-10);
   }
   bool orbFound = false;
-  for (int i=0; i<numOrbitals; i++) {
-    assert (parser.FindToken ("Orbital #"));
-    assert (parser.FindToken ("\n"));
+  for (int i = 0; i < numOrbitals; i++)
+  {
+    assert(parser.FindToken("Orbital #"));
+    assert(parser.FindToken("\n"));
     int spin, n, thisl;
-    assert (parser.ReadInt(spin));
-    assert (parser.ReadInt(n));
-    assert (parser.ReadInt(thisl));
-    if (thisl == l) {
+    assert(parser.ReadInt(spin));
+    assert(parser.ReadInt(n));
+    assert(parser.ReadInt(thisl));
+    if (thisl == l)
+    {
       std::vector<double> ul(numPoints);
-      for (int i=0; i<numPoints; i++)
-	assert (parser.ReadDouble(ul[i]));
+      for (int i = 0; i < numPoints; i++)
+        assert(parser.ReadDouble(ul[i]));
       ChannelPotentials[l].ul.Init(PotentialGrid, ul);
       ChannelPotentials[l].HasProjector = true;
-      ChannelPotentials[l].n_principal = n;
-      orbFound = true;
+      ChannelPotentials[l].n_principal  = n;
+      orbFound                          = true;
     }
   }
-  if (!orbFound) {
+  if (!orbFound)
+  {
     std::cerr << "Could not file orbital with l=" << l
-	 << " in file ""filename""" << std::endl;
+              << " in file "
+                 "filename"
+                 ""
+              << std::endl;
     exit(1);
   }
   return true;
 }
 
-int
-PseudoClass::GetNumChannels()
-{
-  return ChannelPotentials.size();
-}
+int PseudoClass::GetNumChannels() { return ChannelPotentials.size(); }
 
-bool
-PseudoClass::HaveProjectors()
+bool PseudoClass::HaveProjectors()
 {
   bool has = true;
-  for (int i=0; i<ChannelPotentials.size(); i++)
+  for (int i = 0; i < ChannelPotentials.size(); i++)
     has = has && ChannelPotentials[i].HasProjector;
   return has;
 }
 
 
-
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   // Create list of acceptable command-line parameters
   std::list<ParamClass> argList;
   // input formats
-  argList.push_back(ParamClass("fhi_pot",   true));
+  argList.push_back(ParamClass("fhi_pot", true));
   argList.push_back(ParamClass("casino_pot", true));
-  argList.push_back(ParamClass("bfd_pot",    true));
+  argList.push_back(ParamClass("bfd_pot", true));
   argList.push_back(ParamClass("gamess_pot", true));
   argList.push_back(ParamClass("upf_pot", true));
 
   // Projector parameters
-  argList.push_back(ParamClass("casino_us",  true));
-  argList.push_back(ParamClass("casino_up",  true));
-  argList.push_back(ParamClass("casino_ud",  true));
-  argList.push_back(ParamClass("casino_uf",  true));
-  argList.push_back(ParamClass("s_ref",  true));
-  argList.push_back(ParamClass("p_ref",  true));
-  argList.push_back(ParamClass("d_ref",  true));
-  argList.push_back(ParamClass("f_ref",  true));
-  argList.push_back(ParamClass("g_ref",  true));
-  argList.push_back(ParamClass("xml",    true));
-  argList.push_back(ParamClass("tm",     true));
-  argList.push_back(ParamClass("upf",    true));
-  argList.push_back(ParamClass("fhi",    true));
-  argList.push_back(ParamClass("fpmd",   true));
+  argList.push_back(ParamClass("casino_us", true));
+  argList.push_back(ParamClass("casino_up", true));
+  argList.push_back(ParamClass("casino_ud", true));
+  argList.push_back(ParamClass("casino_uf", true));
+  argList.push_back(ParamClass("s_ref", true));
+  argList.push_back(ParamClass("p_ref", true));
+  argList.push_back(ParamClass("d_ref", true));
+  argList.push_back(ParamClass("f_ref", true));
+  argList.push_back(ParamClass("g_ref", true));
+  argList.push_back(ParamClass("xml", true));
+  argList.push_back(ParamClass("tm", true));
+  argList.push_back(ParamClass("upf", true));
+  argList.push_back(ParamClass("fhi", true));
+  argList.push_back(ParamClass("fpmd", true));
   argList.push_back(ParamClass("casino", true));
   argList.push_back(ParamClass("log_grid", false));
   argList.push_back(ParamClass("local_channel", true));
@@ -1884,37 +1993,38 @@ int main(int argc, char **argv)
 
   CommandLineParserClass parser(argList);
   bool success = parser.Parse(argc, argv);
-  if (!success || parser.NumFiles()!=0) {
+  if (!success || parser.NumFiles() != 0)
+  {
     std::cerr << "Usage:  ppconvert  options\n"
-         << "  Options include:    \n"
-         << "     Input formats:   \n"
-         << "   --casino_pot fname \n"
-         << "   --fhi_pot    fname \n"
-         << "   --upf_pot    fname \n"
-         << "   --bfd_pot    fname \n"
-         << "   --gamess_pot fname \n"
-         << "     Output formats:  \n"
-         << "   --xml  fname.xml   \n"
-         << "   --tm   fname.tm    \n"
-         << "   --upf  fname.upf   \n"
-         << "   --fhi  fname.fhi   \n"
-         << "   --fpmd  fname.xml  \n"
-         << "   --casino fname.xml \n"
-         << "     Reference states:\n"
-         << "   --casino_us fname  \n"
-         << "   --casino_up fname  \n"
-         << "   --casino_ud fname  \n"
-         << "   --casino_uf fname  \n"
-         << "   --casino_ug fname  \n"
-         << "   --s_ref state      \n"
-         << "   --p_ref state      \n"
-         << "   --d_ref state      \n"
-         << "   --f_ref state      \n"
-         << "   --g_ref state      \n"
-         << "     Other options:   \n"
-         << "   --log_grid         \n"
-         << "   --local_channel l (l=0(s),1(p),2(d),3(f),..., default largest possible) \n"
-         << "   --density_mix beta (0 <= beta < 1.0, default 0.75) \n";
+              << "  Options include:    \n"
+              << "     Input formats:   \n"
+              << "   --casino_pot fname \n"
+              << "   --fhi_pot    fname \n"
+              << "   --upf_pot    fname \n"
+              << "   --bfd_pot    fname \n"
+              << "   --gamess_pot fname \n"
+              << "     Output formats:  \n"
+              << "   --xml  fname.xml   \n"
+              << "   --tm   fname.tm    \n"
+              << "   --upf  fname.upf   \n"
+              << "   --fhi  fname.fhi   \n"
+              << "   --fpmd  fname.xml  \n"
+              << "   --casino fname.xml \n"
+              << "     Reference states:\n"
+              << "   --casino_us fname  \n"
+              << "   --casino_up fname  \n"
+              << "   --casino_ud fname  \n"
+              << "   --casino_uf fname  \n"
+              << "   --casino_ug fname  \n"
+              << "   --s_ref state      \n"
+              << "   --p_ref state      \n"
+              << "   --d_ref state      \n"
+              << "   --f_ref state      \n"
+              << "   --g_ref state      \n"
+              << "     Other options:   \n"
+              << "   --log_grid         \n"
+              << "   --local_channel l (l=0(s),1(p),2(d),3(f),..., default largest possible) \n"
+              << "   --density_mix beta (0 <= beta < 1.0, default 0.75) \n";
     exit(1);
   }
 
@@ -1934,76 +2044,88 @@ int main(int argc, char **argv)
 
   if (parser.Found("casino_pot"))
     nlpp.ReadCASINO_PP(parser.GetArg("casino_pot"));
-  else if (parser.Found ("bfd_pot"))
-    nlpp.ReadBFD_PP (parser.GetArg ("bfd_pot"));
-  else if (parser.Found ("fhi_pot"))
-    nlpp.ReadFHI_PP (parser.GetArg ("fhi_pot"));
-  else if (parser.Found ("upf_pot"))
-    nlpp.ReadUPF_PP (parser.GetArg ("upf_pot"));
-  else if (parser.Found ("gamess_pot"))
-    nlpp.ReadGAMESS_PP (parser.GetArg("gamess_pot"));
-  else {
+  else if (parser.Found("bfd_pot"))
+    nlpp.ReadBFD_PP(parser.GetArg("bfd_pot"));
+  else if (parser.Found("fhi_pot"))
+    nlpp.ReadFHI_PP(parser.GetArg("fhi_pot"));
+  else if (parser.Found("upf_pot"))
+    nlpp.ReadUPF_PP(parser.GetArg("upf_pot"));
+  else if (parser.Found("gamess_pot"))
+    nlpp.ReadGAMESS_PP(parser.GetArg("gamess_pot"));
+  else
+  {
     std::cerr << "Need to specify a potential file with --casino_pot "
-	 << "or --bfd_pot or --fhi_pot or --upf_pot or --gamess_pot.\n";
+              << "or --bfd_pot or --fhi_pot or --upf_pot or --gamess_pot.\n";
     exit(1);
   }
 
   // Now check how the projectors are specified
-  if (!nlpp.HaveProjectors()) {
+  if (!nlpp.HaveProjectors())
+  {
     int numChannels = nlpp.GetNumChannels();
-    if (numChannels > 0) {
-      if (parser.Found ("s_ref"))
-	nlpp.CalcProjector (parser.GetArg("s_ref"), 0);
+    if (numChannels > 0)
+    {
+      if (parser.Found("s_ref"))
+        nlpp.CalcProjector(parser.GetArg("s_ref"), 0);
       else if (parser.Found("casino_us"))
-	nlpp.ReadCASINO_WF(parser.GetArg("casino_us"), 0);
-      else {
-	std::cerr << "Please specify the s-channel projector with either "
-	     << " --s_ref or --casino_us.\n";
-	// exit(-1);
+        nlpp.ReadCASINO_WF(parser.GetArg("casino_us"), 0);
+      else
+      {
+        std::cerr << "Please specify the s-channel projector with either "
+                  << " --s_ref or --casino_us.\n";
+        // exit(-1);
       }
     }
-    if (numChannels > 1) {
-      if (parser.Found ("p_ref"))
-	nlpp.CalcProjector (parser.GetArg("p_ref"), 1);
+    if (numChannels > 1)
+    {
+      if (parser.Found("p_ref"))
+        nlpp.CalcProjector(parser.GetArg("p_ref"), 1);
       else if (parser.Found("casino_up"))
-	nlpp.ReadCASINO_WF(parser.GetArg("casino_up"), 1);
-      else {
-	std::cerr << "Please specify the p-channel projector with either "
-	     << " --p_ref or --casino_up.\n";
-	// exit(-1);
+        nlpp.ReadCASINO_WF(parser.GetArg("casino_up"), 1);
+      else
+      {
+        std::cerr << "Please specify the p-channel projector with either "
+                  << " --p_ref or --casino_up.\n";
+        // exit(-1);
       }
     }
-    if (numChannels > 2) {
-      if (parser.Found ("d_ref"))
-	nlpp.CalcProjector (parser.GetArg("d_ref"), 2);
-      else if(parser.Found("casino_ud"))
-	nlpp.ReadCASINO_WF(parser.GetArg("casino_ud"), 2);
-      else {
-	std::cerr << "Please specify the d-channel projector with either "
-	     << " --d_ref or --casino_ud.\n";
-	// exit(-1);
+    if (numChannels > 2)
+    {
+      if (parser.Found("d_ref"))
+        nlpp.CalcProjector(parser.GetArg("d_ref"), 2);
+      else if (parser.Found("casino_ud"))
+        nlpp.ReadCASINO_WF(parser.GetArg("casino_ud"), 2);
+      else
+      {
+        std::cerr << "Please specify the d-channel projector with either "
+                  << " --d_ref or --casino_ud.\n";
+        // exit(-1);
       }
     }
-    if (numChannels > 3) {
-      if (parser.Found ("f_ref"))
-	nlpp.CalcProjector (parser.GetArg("f_ref"), 3);
-      else if(parser.Found("casino_uf"))
-	nlpp.ReadCASINO_WF(parser.GetArg("casino_uf"), 3);
-      else {
-	std::cerr << "Please specify the f-channel projector with either "
-	     << " --f_ref or --casino_uf.\n";
-	// exit(-1);
+    if (numChannels > 3)
+    {
+      if (parser.Found("f_ref"))
+        nlpp.CalcProjector(parser.GetArg("f_ref"), 3);
+      else if (parser.Found("casino_uf"))
+        nlpp.ReadCASINO_WF(parser.GetArg("casino_uf"), 3);
+      else
+      {
+        std::cerr << "Please specify the f-channel projector with either "
+                  << " --f_ref or --casino_uf.\n";
+        // exit(-1);
       }
     }
-    if (numChannels > 4) {
-      if (parser.Found ("g_ref"))
-	nlpp.CalcProjector (parser.GetArg("g_ref"), 4);
-      else if(parser.Found("casino_ug"))
-	nlpp.ReadCASINO_WF(parser.GetArg("casino_ug"), 4);
-      else {
-	std::cerr << "Please specify the g-channel projector with either "
-	     << " --g_ref or --casino_ug.\n";
-	// exit(-1);
+    if (numChannels > 4)
+    {
+      if (parser.Found("g_ref"))
+        nlpp.CalcProjector(parser.GetArg("g_ref"), 4);
+      else if (parser.Found("casino_ug"))
+        nlpp.ReadCASINO_WF(parser.GetArg("casino_ug"), 4);
+      else
+      {
+        std::cerr << "Please specify the g-channel projector with either "
+                  << " --g_ref or --casino_ug.\n";
+        // exit(-1);
       }
     }
   }
@@ -2013,28 +2135,25 @@ int main(int argc, char **argv)
     nlpp.WriteXML(parser.GetArg("xml"));
   if (parser.Found("tm"))
     nlpp.WriteABINIT(parser.GetArg("tm"));
-  if (parser.Found ("upf"))
-    nlpp.WriteUPF (parser.GetArg("upf"));
-  if (parser.Found ("fhi"))
-    nlpp.WriteFHI (parser.GetArg("fhi"));
-  if (parser.Found ("fpmd"))
-    nlpp.WriteFPMD (parser.GetArg("fpmd"));
-  if (parser.Found ("casino"))
-    nlpp.WriteCASINO (parser.GetArg("casino"));
+  if (parser.Found("upf"))
+    nlpp.WriteUPF(parser.GetArg("upf"));
+  if (parser.Found("fhi"))
+    nlpp.WriteFHI(parser.GetArg("fhi"));
+  if (parser.Found("fpmd"))
+    nlpp.WriteFPMD(parser.GetArg("fpmd"));
+  if (parser.Found("casino"))
+    nlpp.WriteCASINO(parser.GetArg("casino"));
 
-//   nlpp.WriteXML(xmlFile);
-//   nlpp.WriteABINIT();
+  //   nlpp.WriteXML(xmlFile);
+  //   nlpp.WriteABINIT();
   nlpp.WriteASCII();
 
-//   nlpp.ReadCASINO_PP ("b_pp.data.HF");
-//   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 0);
-//   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 1);
-//   nlpp.ReadCASINO_WF ("awfn.data_s2d1_2D", 2);
-//   nlpp.WriteXML("test.xml");
+  //   nlpp.ReadCASINO_PP ("b_pp.data.HF");
+  //   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 0);
+  //   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 1);
+  //   nlpp.ReadCASINO_WF ("awfn.data_s2d1_2D", 2);
+  //   nlpp.WriteXML("test.xml");
 }
-
-
-
 
 
 #include "common/IO.h"
@@ -2048,53 +2167,54 @@ int main(int argc, char **argv)
 //}
 
 
-
-bool
-PseudoClass::GetNextState (std::string &state, int &n, int &l, double &occ)
+bool PseudoClass::GetNextState(std::string& state, int& n, int& l, double& occ)
 {
   if (state.length() <= 0)
     return false;
 
-  if ((state[0]<'1') || (state[0] > '9')) {
+  if ((state[0] < '1') || (state[0] > '9'))
+  {
     std::cerr << "Error parsing reference state.\n";
     abort();
   }
-  n = state[0] - '0';
-  std::string channel = state.substr (1,1);
-  if ((channel != "s") && (channel != "p") &&
-      (channel != "d") && (channel != "f") && (channel != "g")) {
+  n                   = state[0] - '0';
+  std::string channel = state.substr(1, 1);
+  if ((channel != "s") && (channel != "p") && (channel != "d") && (channel != "f") && (channel != "g"))
+  {
     std::cerr << "Unrecognized angular momentum channel in reference state.\n";
     abort();
   }
   l = ChannelRevMap[channel];
   // cerr << "n=" << n << "  l=" << l << endl;
-  if (state[2] != '(') {
+  if (state[2] != '(')
+  {
     std::cerr << "Error parsing occupancy in reference state.\n";
     abort();
   }
-  state.erase(0,3);
+  state.erase(0, 3);
 
   std::string occString;
-  while ((state.length() > 0) && (state[0] != ')')) {
-    occString.append (state.substr(0,1));
-    state.erase(0,1);
+  while ((state.length() > 0) && (state[0] != ')'))
+  {
+    occString.append(state.substr(0, 1));
+    state.erase(0, 1);
   }
-  char *endptr;
-  const char *occStr = occString.c_str();
-  occ = strtod (occStr, &endptr);
-  if (state[0] != ')') {
+  char* endptr;
+  const char* occStr = occString.c_str();
+  occ                = strtod(occStr, &endptr);
+  if (state[0] != ')')
+  {
     std::cerr << "Expected a ')' in parsing reference state.\n";
     abort();
   }
-  state.erase(0,1);
+  state.erase(0, 1);
 
   return true;
 }
 
 
 #include "common/DFTAtom.h"
-void
-PseudoClass::CalcProjector(std::string refstate, int lchannel)
+void PseudoClass::CalcProjector(std::string refstate, int lchannel)
 {
   DFTAtom atom;
   std::string saveState = refstate;
@@ -2105,87 +2225,70 @@ PseudoClass::CalcProjector(std::string refstate, int lchannel)
   int n, l;
   double occ;
   int lindex = -1;
-  int index = 0;
-  while (GetNextState(refstate, n, l, occ)) {
-    nList.push_back (n);
-    lList.push_back (l);
-    occList.push_back (occ);
+  int index  = 0;
+  while (GetNextState(refstate, n, l, occ))
+  {
+    nList.push_back(n);
+    lList.push_back(l);
+    occList.push_back(occ);
     if (l == lchannel && lindex == -1)
       lindex = index;
     index++;
   }
-  if (lindex == -1) {
-    nList.push_back(lchannel+1);
+  if (lindex == -1)
+  {
+    nList.push_back(lchannel + 1);
     lList.push_back(lchannel);
     occList.push_back(0.0);
-    lindex = nList.size()-1;
+    lindex = nList.size() - 1;
   }
 
   atom.RadialWFs.resize(nList.size());
-  for (int i=0; i<atom.RadialWFs.size(); i++) {
+  for (int i = 0; i < atom.RadialWFs.size(); i++)
+  {
     // atom.RadialWFs(i).n = lList[i]+1;
-    atom.RadialWFs(i).n = nList[i];
-    atom.RadialWFs(i).l = lList[i];
+    atom.RadialWFs(i).n         = nList[i];
+    atom.RadialWFs(i).l         = lList[i];
     atom.RadialWFs(i).Occupancy = occList[i];
-    atom.RadialWFs(i).Energy = -0.5;
+    atom.RadialWFs(i).Energy    = -0.5;
   }
   // Define a grid for solving
-  OptimalGrid *grid = new OptimalGrid(PseudoCharge, PotentialGrid.End());
-  atom.SetGrid (grid);
+  std::shared_ptr<Grid> optimalGrid = std::make_shared<OptimalGrid>(PseudoCharge, PotentialGrid.End());
+  atom.SetGrid(optimalGrid);
   // Set the potential
-  atom.SetBarePot (this);
+  atom.SetBarePot(this);
   // Solve atom
   atom.NewMix = DensityMix;
   std::cerr << "Solving atom for reference state " << saveState << ":\n";
   atom.Solve();
 
   // Now, initialize the channel u functions
-  std::vector<double> ul(PotentialGrid.NumPoints()),
-    rhoAtom(PotentialGrid.NumPoints());
-  for (int i=0; i<ul.size(); i++) {
-    double r = PotentialGrid[i];
-    ul[i] = sqrt(4.0*M_PI)*atom.RadialWFs(lindex).u(r);
+  std::vector<double> ul(PotentialGrid.NumPoints()), rhoAtom(PotentialGrid.NumPoints());
+  for (int i = 0; i < ul.size(); i++)
+  {
+    double r   = PotentialGrid[i];
+    ul[i]      = sqrt(4.0 * M_PI) * atom.RadialWFs(lindex).u(r);
     rhoAtom[i] = atom.rho(r);
   }
-  ChannelPotentials[lchannel].ul.Init (PotentialGrid, ul);
+  ChannelPotentials[lchannel].ul.Init(PotentialGrid, ul);
   ChannelPotentials[lchannel].HasProjector = true;
-  ChannelPotentials[lchannel].Occupation = occList[lindex];
+  ChannelPotentials[lchannel].Occupation   = occList[lindex];
   RhoAtom.Init(PotentialGrid, rhoAtom);
 }
 
-double
-PseudoClass::V(double r)
-{ return ChannelPotentials[LocalChannel].Vl(r); }
+double PseudoClass::V(double r) { return ChannelPotentials[LocalChannel].Vl(r); }
 
-double
-PseudoClass::dVdr(double r)
-{ return ChannelPotentials[LocalChannel].Vl.Deriv(r); }
+double PseudoClass::dVdr(double r) { return ChannelPotentials[LocalChannel].Vl.Deriv(r); }
 
-double
-PseudoClass::d2Vdr2(double r)
-{ return ChannelPotentials[LocalChannel].Vl.Deriv2(r); }
+double PseudoClass::d2Vdr2(double r) { return ChannelPotentials[LocalChannel].Vl.Deriv2(r); }
 
 
-double
-PseudoClass::V(int l, double r)
-{
-  return ChannelPotentials[l].Vl(r);
-}
+double PseudoClass::V(int l, double r) { return ChannelPotentials[l].Vl(r); }
 
-double
-PseudoClass::dVdr(int l, double r)
-{ return ChannelPotentials[l].Vl.Deriv(r); }
+double PseudoClass::dVdr(int l, double r) { return ChannelPotentials[l].Vl.Deriv(r); }
 
-double
-PseudoClass::d2Vdr2(int l, double r)
-{ return ChannelPotentials[l].Vl.Deriv2(r); }
+double PseudoClass::d2Vdr2(int l, double r) { return ChannelPotentials[l].Vl.Deriv2(r); }
 
-void
-PseudoClass::Write(IOSectionClass &out)
-{
-}
+void PseudoClass::Write(IOSectionClass& out) {}
 
-void
-PseudoClass::Read(IOSectionClass &in)
-{
-}
+void PseudoClass::Read(IOSectionClass& in) {}

--- a/src/QMCTools/ppconvert/src/NLPPClass.cc
+++ b/src/QMCTools/ppconvert/src/NLPPClass.cc
@@ -11,6 +11,9 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
+
+
+
 #include "NLPPClass.h"
 #include "XMLWriterClass2.h"
 #include "ParserClass.h"
@@ -20,15 +23,17 @@
 #include <stdlib.h>
 #include <cstdlib>
 
-void ChannelPotentialClass::WriteChannelLog(XMLWriterClass& writer, bool writeVl)
+void
+ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
+					bool writeVl)
 {
   std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a logarithmic grid:
   // r(i) = a*(exp(b*i) - 1)
   const int numPoints = 2001;
-  double end          = Vl.grid.End();
-  double step         = 0.00625;
-  double scale        = end / (expm1(step * (numPoints - 1)));
+  double end = Vl.grid.End();
+  double step  = 0.00625;
+  double scale = end/(expm1(step*(numPoints-1)));
   if (writeVl)
     writer.StartElement("vps");
   else
@@ -36,8 +41,7 @@ void ChannelPotentialClass::WriteChannelLog(XMLWriterClass& writer, bool writeVl
   writer.WriteAttribute("principal-n", n_principal);
   writer.WriteAttribute("l", channels[l]);
   writer.WriteAttribute("spin", -1);
-  if (writeVl)
-  {
+  if (writeVl) {
     writer.WriteAttribute("cutoff", Cutoff);
     writer.WriteAttribute("occupation", Occupation);
   }
@@ -50,17 +54,14 @@ void ChannelPotentialClass::WriteChannelLog(XMLWriterClass& writer, bool writeVl
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
   std::vector<double> data;
-  for (int i = 0; i < numPoints; i++)
-  {
-    double r = scale * (expm1(step * i));
-    if (writeVl)
-    {
-      double rmin = std::min(r, Vl.grid.End());
+  for (int i=0; i<numPoints; i++) {
+    double r  = scale * (expm1(step*i));
+    if (writeVl) {
+      double rmin = std::min (r, Vl.grid.End());
       data.push_back(Vlr(rmin));
     }
-    else
-    {
-      r = std::min(r, ul.grid.End());
+    else {
+      r = std::min (r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -71,12 +72,15 @@ void ChannelPotentialClass::WriteChannelLog(XMLWriterClass& writer, bool writeVl
 }
 
 
-void ChannelPotentialClass::WriteChannelLinear(XMLWriterClass& writer, double dr, double rmax, bool writeVl)
+
+void
+ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
+					   double dr, double rmax, bool writeVl)
 {
   std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a linear grid
   // r(i) = dr * i
-  const int numPoints = (int)round(rmax / dr) + 1;
+  const int numPoints = (int)round(rmax/dr) + 1;
   if (writeVl)
     writer.StartElement("vps");
   else
@@ -84,8 +88,7 @@ void ChannelPotentialClass::WriteChannelLinear(XMLWriterClass& writer, double dr
   writer.WriteAttribute("principal-n", n_principal);
   writer.WriteAttribute("l", channels[l]);
   writer.WriteAttribute("spin", -1);
-  if (writeVl)
-  {
+  if (writeVl) {
     writer.WriteAttribute("cutoff", Cutoff);
     writer.WriteAttribute("occupation", Occupation);
   }
@@ -94,24 +97,21 @@ void ChannelPotentialClass::WriteChannelLinear(XMLWriterClass& writer, double dr
   writer.WriteAttribute("type", "linear");
   writer.WriteAttribute("units", "bohr");
   writer.WriteAttribute("ri", 0.0);
-  writer.WriteAttribute("rf", dr * (double)(numPoints - 1));
+  writer.WriteAttribute("rf", dr*(double)(numPoints-1));
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
   std::vector<double> data;
-  for (int i = 0; i < numPoints; i++)
-  {
-    double r = dr * (double)i;
-    if (writeVl)
-    {
-      r = std::min(r, ul.grid.End());
+  for (int i=0; i<numPoints; i++) {
+    double r  = dr*(double)i;
+    if (writeVl) {
+      r = std::min (r, ul.grid.End());
       if (r < Vl.grid.Start())
-        data.push_back(0.0);
+  	data.push_back(0.0);
       else
-        data.push_back(Vlr(r));
+  	data.push_back(Vlr(r));
     }
-    else
-    {
-      r = std::min(r, ul.grid.End());
+    else {
+      r = std::min (r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -122,251 +122,184 @@ void ChannelPotentialClass::WriteChannelLinear(XMLWriterClass& writer, double dr
 }
 
 
-void PseudoClass::SetupMaps()
+void
+PseudoClass::SetupMaps()
 {
-  UnitToHartreeMap[std::string("hartree")]  = 1.0;
+  UnitToHartreeMap[std::string("hartree")] = 1.0;
   UnitToHartreeMap[std::string("hartrees")] = 1.0;
   UnitToHartreeMap[std::string("Hartrees")] = 1.0;
-  UnitToHartreeMap[std::string("rydberg")]  = 0.5;
-  UnitToHartreeMap[std::string("ev")]       = 0.03674932595264097934;
+  UnitToHartreeMap[std::string("rydberg")] = 0.5;
+  UnitToHartreeMap[std::string("ev")]      = 0.03674932595264097934;
 
   UnitToBohrMap[std::string("bohr")]     = 1.0;
   UnitToBohrMap[std::string("atomic")]   = 1.0;
   UnitToBohrMap[std::string("angstrom")] = 1.8897261;
 
-  XCMap[XC_LDA]    = "LDA";
-  XCRevMap["LDA"]  = XC_LDA;
-  XCRevMap["lda"]  = XC_LDA;
-  XCMap[XC_GGA]    = "GGA";
-  XCRevMap["GGA"]  = XC_GGA;
-  XCRevMap["gga"]  = XC_LDA;
-  XCMap[XC_HF]     = "HF";
-  XCRevMap["HF"]   = XC_HF;
-  XCRevMap["hf"]   = XC_LDA;
-  XCMap[XC_DF]     = "DF";
-  XCRevMap["DF"]   = XC_DF;
-  XCRevMap["df"]   = XC_DF;
-  XCMap[XC_NONE]   = "NONE";
-  XCRevMap["NONE"] = XC_NONE;
-  XCRevMap["none"] = XC_NONE;
+  XCMap[XC_LDA] ="LDA" ; XCRevMap["LDA"] =XC_LDA;  XCRevMap["lda"] =XC_LDA;
+  XCMap[XC_GGA] ="GGA" ; XCRevMap["GGA"] =XC_GGA;  XCRevMap["gga"] =XC_LDA;
+  XCMap[XC_HF]  ="HF"  ; XCRevMap["HF"]  =XC_HF;   XCRevMap["hf"]  =XC_LDA;
+  XCMap[XC_DF]  ="DF"  ; XCRevMap["DF"]  =XC_DF;   XCRevMap["df"]  =XC_DF;
+  XCMap[XC_NONE]="NONE"; XCRevMap["NONE"]=XC_NONE; XCRevMap["none"]=XC_NONE;
 
-  ChannelMap[0]      = "s";
-  ChannelRevMap["s"] = 0;
-  ChannelMap[1]      = "p";
-  ChannelRevMap["p"] = 1;
-  ChannelMap[2]      = "d";
-  ChannelRevMap["d"] = 2;
-  ChannelMap[3]      = "f";
-  ChannelRevMap["f"] = 3;
-  ChannelMap[4]      = "g";
-  ChannelRevMap["g"] = 4;
-  ChannelMap[5]      = "h";
-  ChannelRevMap["h"] = 5;
-  ChannelMap[6]      = "i";
-  ChannelRevMap["i"] = 6;
-  ZToSymbolMap[1]    = "H";
-  ZToSymbolMap[2]    = "He";
-  ZToSymbolMap[3]    = "Li";
-  ZToSymbolMap[4]    = "Be";
-  ZToSymbolMap[5]    = "B";
-  ZToSymbolMap[6]    = "C";
-  ZToSymbolMap[7]    = "N";
-  ZToSymbolMap[8]    = "O";
-  ZToSymbolMap[9]    = "F";
-  ZToSymbolMap[10]   = "Ne";
-  ZToSymbolMap[11]   = "Na";
-  ZToSymbolMap[12]   = "Mg";
-  ZToSymbolMap[13]   = "Al";
-  ZToSymbolMap[14]   = "Si";
-  ZToSymbolMap[15]   = "P";
-  ZToSymbolMap[16]   = "S";
-  ZToSymbolMap[17]   = "Cl";
-  ZToSymbolMap[18]   = "Ar";
-  ZToSymbolMap[19]   = "K";
-  ZToSymbolMap[20]   = "Ca";
-  ZToSymbolMap[21]   = "Sc";
-  ZToSymbolMap[22]   = "Ti";
-  ZToSymbolMap[23]   = "V";
-  ZToSymbolMap[24]   = "Cr";
-  ZToSymbolMap[25]   = "Mn";
-  ZToSymbolMap[26]   = "Fe";
-  ZToSymbolMap[27]   = "Co";
-  ZToSymbolMap[28]   = "Ni";
-  ZToSymbolMap[29]   = "Cu";
-  ZToSymbolMap[30]   = "Zn";
-  ZToSymbolMap[31]   = "Ga";
-  ZToSymbolMap[32]   = "Ge";
-  ZToSymbolMap[33]   = "As";
-  ZToSymbolMap[34]   = "Se";
-  ZToSymbolMap[35]   = "Br";
-  ZToSymbolMap[36]   = "Kr";
-  ZToSymbolMap[37]   = "Rb";
-  ZToSymbolMap[38]   = "Sr";
-  ZToSymbolMap[39]   = "Y";
-  ZToSymbolMap[40]   = "Zr";
-  ZToSymbolMap[41]   = "Nb";
-  ZToSymbolMap[42]   = "Mo";
-  ZToSymbolMap[43]   = "Tc";
-  ZToSymbolMap[44]   = "Ru";
-  ZToSymbolMap[45]   = "Rh";
-  ZToSymbolMap[46]   = "Pd";
-  ZToSymbolMap[47]   = "Ag";
-  ZToSymbolMap[48]   = "Cd";
-  ZToSymbolMap[49]   = "In";
-  ZToSymbolMap[50]   = "Sn";
-  ZToSymbolMap[51]   = "Sb";
-  ZToSymbolMap[52]   = "Te";
-  ZToSymbolMap[53]   = "I";
-  ZToSymbolMap[54]   = "Xe";
-  ZToSymbolMap[55]   = "Cs";
-  ZToSymbolMap[56]   = "Ba";
-  ZToSymbolMap[57]   = "La";
-  ZToSymbolMap[58]   = "Ce";
-  ZToSymbolMap[59]   = "Pr";
-  ZToSymbolMap[60]   = "Nd";
-  ZToSymbolMap[61]   = "Pm";
-  ZToSymbolMap[62]   = "Sm";
-  ZToSymbolMap[63]   = "Eu";
-  ZToSymbolMap[64]   = "Gd";
-  ZToSymbolMap[65]   = "Tb";
-  ZToSymbolMap[66]   = "Dy";
-  ZToSymbolMap[67]   = "Ho";
-  ZToSymbolMap[68]   = "Er";
-  ZToSymbolMap[69]   = "Tm";
-  ZToSymbolMap[70]   = "Yb";
-  ZToSymbolMap[71]   = "Lu";
-  ZToSymbolMap[72]   = "Hf";
-  ZToSymbolMap[73]   = "Ta";
-  ZToSymbolMap[74]   = "W";
-  ZToSymbolMap[75]   = "Re";
-  ZToSymbolMap[76]   = "Os";
-  ZToSymbolMap[77]   = "Ir";
-  ZToSymbolMap[78]   = "Pt";
-  ZToSymbolMap[79]   = "Au";
-  ZToSymbolMap[80]   = "Hg";
-  ZToSymbolMap[81]   = "Tl";
-  ZToSymbolMap[82]   = "Pb";
-  ZToSymbolMap[83]   = "Bi";
-  ZToSymbolMap[84]   = "Po";
-  ZToSymbolMap[85]   = "At";
-  ZToSymbolMap[86]   = "Rn";
-  ZToSymbolMap[87]   = "Fr";
-  ZToSymbolMap[88]   = "Ra";
-  ZToSymbolMap[89]   = "Ac";
-  ZToSymbolMap[90]   = "Th";
-  ZToSymbolMap[91]   = "Pa";
-  ZToSymbolMap[92]   = "U";
-  ZToSymbolMap[93]   = "Np";
-  ZToSymbolMap[94]   = "Pu";
-  ZToSymbolMap[95]   = "Am";
-  ZToSymbolMap[96]   = "Cm";
-  ZToSymbolMap[97]   = "Bk";
-  ZToSymbolMap[98]   = "Cf";
-  ZToSymbolMap[99]   = "Es";
-  ZToSymbolMap[100]  = "Fm";
-  ZToSymbolMap[101]  = "Mc";
-  ZToSymbolMap[102]  = "No";
-  ZToSymbolMap[103]  = "Lw";
+  ChannelMap[0] = "s";  ChannelRevMap["s"] = 0;
+  ChannelMap[1] = "p";  ChannelRevMap["p"] = 1;
+  ChannelMap[2] = "d";  ChannelRevMap["d"] = 2;
+  ChannelMap[3] = "f";  ChannelRevMap["f"] = 3;
+  ChannelMap[4] = "g";  ChannelRevMap["g"] = 4;
+  ChannelMap[5] = "h";  ChannelRevMap["h"] = 5;
+  ChannelMap[6] = "i";  ChannelRevMap["i"] = 6;
+  ZToSymbolMap[1]   = "H";  ZToSymbolMap[2]   = "He";
+  ZToSymbolMap[3]   = "Li"; ZToSymbolMap[4]   = "Be";
+  ZToSymbolMap[5]   = "B";  ZToSymbolMap[6]   = "C";
+  ZToSymbolMap[7]   = "N";  ZToSymbolMap[8]   = "O";
+  ZToSymbolMap[9]   = "F";  ZToSymbolMap[10]  = "Ne";
+  ZToSymbolMap[11]  = "Na"; ZToSymbolMap[12]  = "Mg";
+  ZToSymbolMap[13]  = "Al"; ZToSymbolMap[14]  = "Si";
+  ZToSymbolMap[15]  = "P";  ZToSymbolMap[16]  = "S";
+  ZToSymbolMap[17]  = "Cl"; ZToSymbolMap[18]  = "Ar";
+  ZToSymbolMap[19]  = "K";  ZToSymbolMap[20]  = "Ca";
+  ZToSymbolMap[21]  = "Sc"; ZToSymbolMap[22]  = "Ti";
+  ZToSymbolMap[23]  = "V";  ZToSymbolMap[24]  = "Cr";
+  ZToSymbolMap[25]  = "Mn"; ZToSymbolMap[26]  = "Fe";
+  ZToSymbolMap[27]  = "Co"; ZToSymbolMap[28]  = "Ni";
+  ZToSymbolMap[29]  = "Cu"; ZToSymbolMap[30]  = "Zn";
+  ZToSymbolMap[31]  = "Ga"; ZToSymbolMap[32]  = "Ge";
+  ZToSymbolMap[33]  = "As"; ZToSymbolMap[34]  = "Se";
+  ZToSymbolMap[35]  = "Br"; ZToSymbolMap[36]  = "Kr";
+  ZToSymbolMap[37]  = "Rb"; ZToSymbolMap[38]  = "Sr";
+  ZToSymbolMap[39]  = "Y";  ZToSymbolMap[40]  = "Zr";
+  ZToSymbolMap[41]  = "Nb"; ZToSymbolMap[42]  = "Mo";
+  ZToSymbolMap[43]  = "Tc"; ZToSymbolMap[44]  = "Ru";
+  ZToSymbolMap[45]  = "Rh"; ZToSymbolMap[46]  = "Pd";
+  ZToSymbolMap[47]  = "Ag"; ZToSymbolMap[48]  = "Cd";
+  ZToSymbolMap[49]  = "In"; ZToSymbolMap[50]  = "Sn";
+  ZToSymbolMap[51]  = "Sb"; ZToSymbolMap[52]  = "Te";
+  ZToSymbolMap[53]  = "I";  ZToSymbolMap[54]  = "Xe";
+  ZToSymbolMap[55]  = "Cs"; ZToSymbolMap[56]  = "Ba";
+  ZToSymbolMap[57]  = "La"; ZToSymbolMap[58]  = "Ce";
+  ZToSymbolMap[59]  = "Pr"; ZToSymbolMap[60]  = "Nd";
+  ZToSymbolMap[61]  = "Pm"; ZToSymbolMap[62]  = "Sm";
+  ZToSymbolMap[63]  = "Eu"; ZToSymbolMap[64]  = "Gd";
+  ZToSymbolMap[65]  = "Tb"; ZToSymbolMap[66]  = "Dy";
+  ZToSymbolMap[67]  = "Ho"; ZToSymbolMap[68]  = "Er";
+  ZToSymbolMap[69]  = "Tm"; ZToSymbolMap[70]  = "Yb";
+  ZToSymbolMap[71]  = "Lu"; ZToSymbolMap[72]  = "Hf";
+  ZToSymbolMap[73]  = "Ta"; ZToSymbolMap[74]  = "W";
+  ZToSymbolMap[75]  = "Re"; ZToSymbolMap[76]  = "Os";
+  ZToSymbolMap[77]  = "Ir"; ZToSymbolMap[78]  = "Pt";
+  ZToSymbolMap[79]  = "Au"; ZToSymbolMap[80]  = "Hg";
+  ZToSymbolMap[81]  = "Tl"; ZToSymbolMap[82]  = "Pb";
+  ZToSymbolMap[83]  = "Bi"; ZToSymbolMap[84]  = "Po";
+  ZToSymbolMap[85]  = "At"; ZToSymbolMap[86]  = "Rn";
+  ZToSymbolMap[87]  = "Fr"; ZToSymbolMap[88]  = "Ra";
+  ZToSymbolMap[89]  = "Ac"; ZToSymbolMap[90]  = "Th";
+  ZToSymbolMap[91]  = "Pa"; ZToSymbolMap[92]  = "U";
+  ZToSymbolMap[93]  = "Np"; ZToSymbolMap[94]  = "Pu";
+  ZToSymbolMap[95]  = "Am"; ZToSymbolMap[96]  = "Cm";
+  ZToSymbolMap[97]  = "Bk"; ZToSymbolMap[98]  = "Cf";
+  ZToSymbolMap[99]  = "Es"; ZToSymbolMap[100] = "Fm";
+  ZToSymbolMap[101] = "Mc"; ZToSymbolMap[102] = "No";
+  ZToSymbolMap[103] = "Lw";
 
-  ZToMassMap[1]   = 1.00794;
-  ZToMassMap[2]   = 4.002602;
-  ZToMassMap[3]   = 6.941;
-  ZToMassMap[4]   = 9.012182;
-  ZToMassMap[5]   = 10.811;
-  ZToMassMap[6]   = 12.0107;
-  ZToMassMap[7]   = 14.0067;
-  ZToMassMap[8]   = 15.9994;
-  ZToMassMap[9]   = 18.9984032;
-  ZToMassMap[10]  = 20.1797;
-  ZToMassMap[11]  = 22.98976928;
-  ZToMassMap[12]  = 24.3050;
-  ZToMassMap[13]  = 26.9815386;
-  ZToMassMap[14]  = 28.0855;
-  ZToMassMap[15]  = 30.973762;
-  ZToMassMap[16]  = 32.065;
-  ZToMassMap[17]  = 35.453;
-  ZToMassMap[18]  = 39.948;
-  ZToMassMap[19]  = 39.0983;
-  ZToMassMap[20]  = 40.078;
-  ZToMassMap[21]  = 44.955912;
-  ZToMassMap[22]  = 47.867;
-  ZToMassMap[23]  = 50.9415;
-  ZToMassMap[24]  = 51.9961;
-  ZToMassMap[25]  = 54.938049;
-  ZToMassMap[26]  = 55.845;
-  ZToMassMap[27]  = 58.933200;
-  ZToMassMap[28]  = 58.6934;
-  ZToMassMap[29]  = 63.546;
-  ZToMassMap[30]  = 65.39;
-  ZToMassMap[31]  = 69.723;
-  ZToMassMap[32]  = 72.61;
-  ZToMassMap[33]  = 74.92160;
-  ZToMassMap[34]  = 78.96;
-  ZToMassMap[35]  = 79.904;
-  ZToMassMap[36]  = 83.80;
-  ZToMassMap[37]  = 85.4678;
-  ZToMassMap[38]  = 87.62;
-  ZToMassMap[39]  = 88.90585;
-  ZToMassMap[40]  = 91.224;
-  ZToMassMap[41]  = 92.90638;
-  ZToMassMap[42]  = 95.94;
-  ZToMassMap[43]  = 98;
-  ZToMassMap[44]  = 101.07;
-  ZToMassMap[45]  = 102.90550;
-  ZToMassMap[46]  = 106.42;
-  ZToMassMap[47]  = 107.8682;
-  ZToMassMap[48]  = 112.411;
-  ZToMassMap[49]  = 114.818;
-  ZToMassMap[50]  = 118.710;
-  ZToMassMap[51]  = 121.760;
-  ZToMassMap[52]  = 127.60;
-  ZToMassMap[53]  = 126.90447;
-  ZToMassMap[54]  = 131.29;
-  ZToMassMap[55]  = 132.90545;
-  ZToMassMap[56]  = 137.327;
-  ZToMassMap[57]  = 138.9055;
-  ZToMassMap[58]  = 140.116;
-  ZToMassMap[59]  = 140.90765;
-  ZToMassMap[60]  = 144.24;
-  ZToMassMap[61]  = 145;
-  ZToMassMap[62]  = 150.36;
-  ZToMassMap[63]  = 151.964;
-  ZToMassMap[64]  = 157.25;
-  ZToMassMap[65]  = 158.92534;
-  ZToMassMap[66]  = 162.50;
-  ZToMassMap[67]  = 164.93032;
-  ZToMassMap[68]  = 167.26;
-  ZToMassMap[69]  = 168.93421;
-  ZToMassMap[70]  = 173.04;
-  ZToMassMap[71]  = 174.967;
-  ZToMassMap[72]  = 178.49;
-  ZToMassMap[73]  = 180.9479;
-  ZToMassMap[74]  = 183.84;
-  ZToMassMap[75]  = 186.207;
-  ZToMassMap[76]  = 190.23;
-  ZToMassMap[77]  = 192.217;
-  ZToMassMap[78]  = 195.078;
-  ZToMassMap[79]  = 196.96655;
-  ZToMassMap[80]  = 200.59;
-  ZToMassMap[81]  = 204.3833;
-  ZToMassMap[82]  = 207.2;
-  ZToMassMap[83]  = 208.98038;
-  ZToMassMap[84]  = 209;
-  ZToMassMap[85]  = 210;
-  ZToMassMap[86]  = 222;
-  ZToMassMap[87]  = 223;
-  ZToMassMap[88]  = 226;
-  ZToMassMap[89]  = 227;
-  ZToMassMap[90]  = 232.0381;
-  ZToMassMap[91]  = 231.03588;
-  ZToMassMap[92]  = 238.0289;
-  ZToMassMap[93]  = 237;
-  ZToMassMap[94]  = 244;
-  ZToMassMap[95]  = 243;
-  ZToMassMap[96]  = 247;
-  ZToMassMap[97]  = 247;
-  ZToMassMap[98]  = 251;
-  ZToMassMap[99]  = 252;
+  ZToMassMap[  1] = 1.00794;
+  ZToMassMap[  2] = 4.002602;
+  ZToMassMap[  3] = 6.941;
+  ZToMassMap[  4] = 9.012182;
+  ZToMassMap[  5] = 10.811;
+  ZToMassMap[  6] = 12.0107;
+  ZToMassMap[  7] = 14.0067;
+  ZToMassMap[  8] = 15.9994;
+  ZToMassMap[  9] = 18.9984032;
+  ZToMassMap[ 10] = 20.1797;
+  ZToMassMap[ 11] = 22.98976928;
+  ZToMassMap[ 12] = 24.3050;
+  ZToMassMap[ 13] = 26.9815386;
+  ZToMassMap[ 14] = 28.0855;
+  ZToMassMap[ 15] = 30.973762;
+  ZToMassMap[ 16] = 32.065;
+  ZToMassMap[ 17] = 35.453;
+  ZToMassMap[ 18] = 39.948;
+  ZToMassMap[ 19] = 39.0983;
+  ZToMassMap[ 20] = 40.078;
+  ZToMassMap[ 21] = 44.955912;
+  ZToMassMap[ 22] = 47.867;
+  ZToMassMap[ 23] = 50.9415;
+  ZToMassMap[ 24] = 51.9961;
+  ZToMassMap[ 25] = 54.938049;
+  ZToMassMap[ 26] = 55.845;
+  ZToMassMap[ 27] = 58.933200;
+  ZToMassMap[ 28] = 58.6934;
+  ZToMassMap[ 29] = 63.546;
+  ZToMassMap[ 30] = 65.39;
+  ZToMassMap[ 31] = 69.723;
+  ZToMassMap[ 32] = 72.61;
+  ZToMassMap[ 33] = 74.92160;
+  ZToMassMap[ 34] = 78.96 ;
+  ZToMassMap[ 35] = 79.904;
+  ZToMassMap[ 36] = 83.80;
+  ZToMassMap[ 37] = 85.4678;
+  ZToMassMap[ 38] = 87.62;
+  ZToMassMap[ 39] = 88.90585;
+  ZToMassMap[ 40] = 91.224;
+  ZToMassMap[ 41] = 92.90638;
+  ZToMassMap[ 42] = 95.94;
+  ZToMassMap[ 43] = 98;
+  ZToMassMap[ 44] = 101.07;
+  ZToMassMap[ 45] = 102.90550;
+  ZToMassMap[ 46] = 106.42;
+  ZToMassMap[ 47] = 107.8682;
+  ZToMassMap[ 48] = 112.411;
+  ZToMassMap[ 49] = 114.818;
+  ZToMassMap[ 50] = 118.710;
+  ZToMassMap[ 51] = 121.760;
+  ZToMassMap[ 52] = 127.60;
+  ZToMassMap[ 53] = 126.90447;
+  ZToMassMap[ 54] = 131.29;
+  ZToMassMap[ 55] = 132.90545;
+  ZToMassMap[ 56] = 137.327;
+  ZToMassMap[ 57] = 138.9055;
+  ZToMassMap[ 58] = 140.116;
+  ZToMassMap[ 59] = 140.90765;
+  ZToMassMap[ 60] = 144.24;
+  ZToMassMap[ 61] = 145;
+  ZToMassMap[ 62] = 150.36;
+  ZToMassMap[ 63] = 151.964;
+  ZToMassMap[ 64] = 157.25;
+  ZToMassMap[ 65] = 158.92534;
+  ZToMassMap[ 66] = 162.50;
+  ZToMassMap[ 67] = 164.93032;
+  ZToMassMap[ 68] = 167.26;
+  ZToMassMap[ 69] = 168.93421;
+  ZToMassMap[ 70] = 173.04;
+  ZToMassMap[ 71] = 174.967;
+  ZToMassMap[ 72] = 178.49;
+  ZToMassMap[ 73] = 180.9479;
+  ZToMassMap[ 74] = 183.84;
+  ZToMassMap[ 75] = 186.207;
+  ZToMassMap[ 76] = 190.23;
+  ZToMassMap[ 77] = 192.217;
+  ZToMassMap[ 78] = 195.078;
+  ZToMassMap[ 79] = 196.96655;
+  ZToMassMap[ 80] = 200.59;
+  ZToMassMap[ 81] = 204.3833;
+  ZToMassMap[ 82] = 207.2;
+  ZToMassMap[ 83] = 208.98038;
+  ZToMassMap[ 84] = 209;
+  ZToMassMap[ 85] = 210;
+  ZToMassMap[ 86] = 222;
+  ZToMassMap[ 87] = 223;
+  ZToMassMap[ 88] = 226;
+  ZToMassMap[ 89] = 227;
+  ZToMassMap[ 90] = 232.0381;
+  ZToMassMap[ 91] = 231.03588;
+  ZToMassMap[ 92] = 238.0289;
+  ZToMassMap[ 93] = 237;
+  ZToMassMap[ 94] = 244;
+  ZToMassMap[ 95] = 243;
+  ZToMassMap[ 96] = 247;
+  ZToMassMap[ 97] = 247;
+  ZToMassMap[ 98] = 251;
+  ZToMassMap[ 99] = 252;
   ZToMassMap[100] = 257;
   ZToMassMap[101] = 258;
   ZToMassMap[102] = 259;
@@ -387,21 +320,26 @@ void PseudoClass::SetupMaps()
   ZToMassMap[117] = 293; // UNKNOWN
   ZToMassMap[118] = 294;
 
-  for (int i = 1; i < 103; i++)
+  for (int i=1; i<103; i++)
     SymbolToZMap[ZToSymbolMap[i]] = i;
 }
 
-void PseudoClass::WriteFPMD(std::string fname)
+void
+PseudoClass::WriteFPMD(std::string fname)
 {
   const int numPoints = 2000;
-  const double dr     = 0.005;
+  const double dr = 0.005;
 
   XMLWriterClass writer;
   writer.StartDocument(fname, "1.0", "UTF-8");
   writer.StartElement("fpmd:species");
-  writer.WriteAttribute("xmlns:fpmd", "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0");
-  writer.WriteAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-  writer.WriteAttribute("xsi:schemaLocation", "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0 species.xsd");
+  writer.WriteAttribute("xmlns:fpmd",
+			"http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0");
+  writer.WriteAttribute("xmlns:xsi",
+			"http://www.w3.org/2001/XMLSchema-instance");
+  writer.WriteAttribute
+    ("xsi:schemaLocation",
+     "http://www.quantum-simulation.org/ns/fpmd/fpmd-1.0 species.xsd");
 
   writer.StartElement("description");
   writer.WriteData("ppconvert");
@@ -426,7 +364,7 @@ void PseudoClass::WriteFPMD(std::string fname)
   writer.EndElement(); // "valence_charge"
 
   writer.StartElement("lmax");
-  writer.WriteData(ChannelPotentials.size() - 1);
+  writer.WriteData(ChannelPotentials.size()-1);
   writer.EndElement(); // "lmax"
 
   writer.StartElement("llocal");
@@ -442,37 +380,34 @@ void PseudoClass::WriteFPMD(std::string fname)
   writer.EndElement(); // "rquad"
 
 
+
   writer.StartElement("mesh_spacing");
   writer.WriteData(dr);
   writer.EndElement(); // "rquad"
 
-  for (int il = 0; il < ChannelPotentials.size(); il++)
-  {
-    ChannelPotentialClass& pot = ChannelPotentials[il];
+  for (int il=0; il<ChannelPotentials.size(); il++) {
+    ChannelPotentialClass &pot = ChannelPotentials[il];
     writer.StartElement("projector");
     writer.WriteAttribute("l", pot.l);
     writer.WriteAttribute("size", numPoints);
 
     writer.StartElement("radial_potential");
     std::vector<double> vl(numPoints);
-    for (int ir = 0; ir < numPoints; ir++)
-    {
-      double r = (double)ir * dr;
-      vl[ir]   = (ir == 0) ? pot.Vl(0.0) : pot.Vlr(r) / r;
+    for (int ir=0; ir<numPoints; ir++) {
+      double r = (double)ir*dr;
+      vl[ir] = (ir==0) ? pot.Vl(0.0) : pot.Vlr(r)/r;
     }
     writer.WriteData(vl);
     writer.EndElement(); // "radial_potential"
 
-    if (pot.HasProjector && pot.l != LocalChannel)
-    {
+    if (pot.HasProjector && pot.l != LocalChannel) {
       writer.StartElement("radial_function");
       std::vector<double> ul(numPoints);
-      for (int ir = 0; ir < numPoints; ir++)
-      {
-        double r = (ir == 0) ? 1.0e-8 : (double)ir * dr;
-        ul[ir]   = pot.ul(r) / r;
+      for (int ir=0; ir<numPoints; ir++) {
+	double r = (ir==0) ? 1.0e-8 : (double)ir*dr;
+	ul[ir] = pot.ul(r)/r;
       }
-      ul[0] = 2.0 * ul[1] - ul[2];
+      ul[0] = 2.0*ul[1] - ul[2];
       writer.WriteData(ul);
       writer.EndElement(); // "radial_function"
     }
@@ -481,80 +416,83 @@ void PseudoClass::WriteFPMD(std::string fname)
   }
 
 
+
   writer.EndElement(); // "norm_conserving_pseudopotential"
   writer.EndElement(); // "fpmd:species"
   writer.EndDocument();
 }
 
-void PseudoClass::WriteCASINO(std::string fname)
+void
+PseudoClass::WriteCASINO(std::string fname)
 {
   const int numPoints = 10001;
-  const double rMax   = 10.0;
+  const double rMax = 10.0;
 
-  FILE* fout = fopen(fname.c_str(), "w");
-  if (!fout)
-  {
+  FILE *fout = fopen (fname.c_str(), "w");
+  if (!fout) {
     std::cerr << "Error trying to write " << fname << ".\n";
     abort();
   }
 
-  fprintf(fout, "Pseudopotential in real space for %s\n", ZToSymbolMap[AtomicNumber].c_str());
-  fprintf(fout, "Atomic number and pseudo-charge\n%d %1.2f\n", AtomicNumber, PseudoCharge);
-  fprintf(fout, "Energy units (rydberg/hartree/ev):\nrydberg\n");
-  fprintf(fout, "Angular momentum of local component (0=s,1=p,2=d..)\n%d\n", LocalChannel);
-  fprintf(fout,
-          "NLRULE override (1) VMC/DMC (2) config gen "
-          "(0 ==> input/default value)\n0 0\n");
-  fprintf(fout, "Number of grid points\n%d\n", numPoints);
-  fprintf(fout, "R(i) in atomic units\n");
-  for (int i = 0; i < numPoints; i++)
-  {
-    double r = (double)i / (double)(numPoints - 1) * rMax;
-    fprintf(fout, "  %22.16e\n", r);
+  fprintf (fout, "Pseudopotential in real space for %s\n",
+	   ZToSymbolMap[AtomicNumber].c_str());
+  fprintf (fout, "Atomic number and pseudo-charge\n%d %1.2f\n",
+	   AtomicNumber, PseudoCharge);
+  fprintf (fout, "Energy units (rydberg/hartree/ev):\nrydberg\n");
+  fprintf (fout, "Angular momentum of local component (0=s,1=p,2=d..)\n%d\n",
+	   LocalChannel);
+  fprintf (fout, "NLRULE override (1) VMC/DMC (2) config gen "
+	   "(0 ==> input/default value)\n0 0\n");
+  fprintf (fout, "Number of grid points\n%d\n",
+	   numPoints);
+  fprintf (fout, "R(i) in atomic units\n");
+  for (int i=0; i<numPoints; i++) {
+    double r = (double) i/(double)(numPoints-1)*rMax;
+    fprintf (fout, "  %22.16e\n", r);
   }
 
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
-    ChannelPotentialClass& pot =
-        (l < ChannelPotentials.size()) ? ChannelPotentials[l] : ChannelPotentials[LocalChannel];
-    if (l < ChannelPotentials.size() && l != pot.l)
-    {
+  for (int l=0; l<ChannelPotentials.size(); l++) {
+    ChannelPotentialClass &pot = (l < ChannelPotentials.size()) ?
+      ChannelPotentials[l] : ChannelPotentials[LocalChannel];
+    if (l < ChannelPotentials.size() && l != pot.l) {
       std::cerr << "Channel mismatch in WriteCASINO.\n";
       abort();
     }
-    fprintf(fout, "r*potential (L=%d) in Ry\n", l);
-    for (int i = 0; i < numPoints; i++)
-    {
-      double r = (double)i / (double)(numPoints - 1) * rMax;
-      fprintf(fout, "  %22.16e\n", (i == 0) ? 0.0 : 2.0 * pot.Vlr(r));
+    fprintf (fout, "r*potential (L=%d) in Ry\n",
+	     l);
+    for (int i=0; i<numPoints; i++) {
+      double r = (double) i/(double)(numPoints-1)*rMax;
+      fprintf (fout, "  %22.16e\n",
+	       (i==0) ? 0.0 : 2.0*pot.Vlr(r));
     }
   }
   fclose(fout);
 }
 
-void PseudoClass::WriteXML(std::string fname)
+void
+PseudoClass::WriteXML(std::string fname)
 {
-  //   int rc;
-  //   xmlTextWriterPtr writer = xmlNewTextWriterFilename (fname.c_str(), 0);
+//   int rc;
+//   xmlTextWriterPtr writer = xmlNewTextWriterFilename (fname.c_str(), 0);
 
-  //   rc = xmlTextWriterStartDocument (writer, NULL, "UTF-8", NULL);
-  //   // Start pseudo
-  //   rc = xmlTextWriterStartElement(writer, (xmlChar*)"pseudo");
-  //   rc = xmlTextWriterWriteAttribute
-  //     (writer, (xmlChar*) "version", (xmlChar*)"0.5");
-  //   rc = xmlTextWriterEndElement(writer); // "pseudo"
-  //   rc = xmlTextWriterEndDocument (writer);
-  //   xmlFreeTextWriter(writer);
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-    if (!ChannelPotentials[l].HasProjector)
-    {
-      std::cerr << "Missing projector for l=" << l << ".  Aborting." << std::endl;
+//   rc = xmlTextWriterStartDocument (writer, NULL, "UTF-8", NULL);
+//   // Start pseudo
+//   rc = xmlTextWriterStartElement(writer, (xmlChar*)"pseudo");
+//   rc = xmlTextWriterWriteAttribute
+//     (writer, (xmlChar*) "version", (xmlChar*)"0.5");
+//   rc = xmlTextWriterEndElement(writer); // "pseudo"
+//   rc = xmlTextWriterEndDocument (writer);
+//   xmlFreeTextWriter(writer);
+  for (int l=0; l<ChannelPotentials.size(); l++)
+    if (!ChannelPotentials[l].HasProjector) {
+      std::cerr << "Missing projector for l=" << l
+	   << ".  Aborting." << std::endl;
       exit(1);
     }
   XMLWriterClass writer;
   writer.StartDocument(fname, "1.0", "UTF-8");
   writer.StartElement("pseudo");
-  writer.WriteAttribute("version", "0.5");
+  writer.WriteAttribute ("version", "0.5");
   writer.StartElement("header");
   writer.WriteAttribute("symbol", ZToSymbolMap[AtomicNumber]);
   writer.WriteAttribute("atomic-number", (double)AtomicNumber);
@@ -575,29 +513,27 @@ void PseudoClass::WriteXML(std::string fname)
 
   // NEVER USE LOG GRID
   // Leads to inaccuracy in qmcPACK
-  if (WriteLogGrid && false)
-  {
+  if (WriteLogGrid && false) {
     const int numPoints = 2001;
-    rmax                = PotentialGrid.End();
-    double step         = 0.00625;
-    double scale        = rmax / (expm1(step * (numPoints - 1)));
+    rmax = PotentialGrid.End();
+    double step  = 0.00625;
+    double scale = rmax/(expm1(step*(numPoints-1)));
     writer.StartElement("grid");
     writer.WriteAttribute("type", "log");
     writer.WriteAttribute("units", "bohr");
     writer.WriteAttribute("scale", scale, true);
     writer.WriteAttribute("step", step, true);
-    writer.WriteAttribute("npts", numPoints - 1);
+    writer.WriteAttribute("npts", numPoints-1);
     writer.EndElement(); // "grid"
   }
-  else
-  {
-    rmax          = std::min(10.0, PotentialGrid.End());
-    int numPoints = (int)round(rmax / grid_delta) + 1;
+  else {
+    rmax = std::min (10.0, PotentialGrid.End());
+    int numPoints = (int)round(rmax/grid_delta) + 1;
     writer.StartElement("grid");
     writer.WriteAttribute("type", "linear");
     writer.WriteAttribute("units", "bohr");
     writer.WriteAttribute("ri", 0.0);
-    writer.WriteAttribute("rf", grid_delta * (double)(numPoints - 1), true);
+    writer.WriteAttribute("rf", grid_delta*(double)(numPoints-1), true);
     writer.WriteAttribute("npts", numPoints);
     writer.EndElement(); // "grid"
   }
@@ -606,25 +542,26 @@ void PseudoClass::WriteXML(std::string fname)
   writer.WriteAttribute("units", "hartree");
   writer.WriteAttribute("format", "r*V");
   writer.WriteAttribute("npots-down", (int)ChannelPotentials.size());
-  writer.WriteAttribute("npots-up", 0);
+  writer.WriteAttribute("npots-up"  , 0);
   writer.WriteAttribute("l-local", LocalChannel);
-  for (int l = 0; l < ChannelPotentials.size(); l++)
+  for (int l=0; l<ChannelPotentials.size(); l++)
     if (WriteLogGrid && false)
-      ChannelPotentials[l].WriteChannelLog(writer, true);
+      ChannelPotentials[l].WriteChannelLog (writer, true);
     else
-      ChannelPotentials[l].WriteChannelLinear(writer, grid_delta, rmax, true);
+      ChannelPotentials[l].WriteChannelLinear (writer, grid_delta, rmax, true);
   writer.EndElement(); // "semilocal"
 
   writer.StartElement("pseudowave-functions");
   writer.WriteAttribute("units", "electrons/bohr^(-3/2)");
   writer.WriteAttribute("format", "u_n,l (r) = 1/r R_n,l (r)");
-  writer.WriteAttribute("n-pseudowave-functions-down", (int)ChannelPotentials.size());
+  writer.WriteAttribute("n-pseudowave-functions-down",
+			(int)ChannelPotentials.size());
   writer.WriteAttribute("n-pseudowave-functions-up", 0);
-  for (int l = 0; l < ChannelPotentials.size(); l++)
+  for (int l=0; l<ChannelPotentials.size(); l++)
     if (WriteLogGrid && false)
-      ChannelPotentials[l].WriteChannelLog(writer, false);
+      ChannelPotentials[l].WriteChannelLog (writer, false);
     else
-      ChannelPotentials[l].WriteChannelLinear(writer, grid_delta, rmax, false);
+      ChannelPotentials[l].WriteChannelLinear (writer, grid_delta, rmax, false);
   writer.EndElement(); // "pseudowave-functions"
 
   writer.EndElement(); // "pseudo"
@@ -632,30 +569,29 @@ void PseudoClass::WriteXML(std::string fname)
 }
 
 
-void PseudoClass::Write4Block(FILE* fout, std::vector<double>& data, int indent)
+void
+PseudoClass::Write4Block (FILE *fout, std::vector<double>& data, int indent)
 {
   int N = data.size();
-  for (int i = 0; i < N / 4; i++)
-  {
-    for (int j = 0; j < indent; j++)
-      fprintf(fout, " ");
-    fprintf(fout, "%17.11e %1.17e %1.17e %1.17e\n", data[4 * i + 0], data[4 * i + 1], data[4 * i + 2], data[4 * i + 3]);
+  for (int i=0; i<N/4; i++) {
+    for (int j=0; j<indent; j++)   fprintf (fout, " ");
+    fprintf (fout, "%17.11e %1.17e %1.17e %1.17e\n",
+	     data[4*i+0], data[4*i+1], data[4*i+2], data[4*i+3]);
   }
-  int last = N / 4;
-  for (int i = 0; i < indent; i++)
-    fprintf(fout, " ");
-  for (int j = 0; j < (N % 4); j++)
-    fprintf(fout, "%17.11e ", data[4 * last + j]);
-  fprintf(fout, "\n");
+  int last = N/4;
+  for (int i=0; i<indent; i++)   fprintf (fout, " ");
+  for (int j=0; j<(N % 4); j++)
+    fprintf (fout, "%17.11e ", data[4*last+j]);
+  fprintf (fout, "\n");
 }
 
 
-void PseudoClass::WriteUPF(std::string fileName)
+void
+PseudoClass::WriteUPF (std::string fileName)
 {
   std::cerr << "LocalChannel = " << LocalChannel << std::endl;
-  FILE* fout = fopen(fileName.c_str(), "w");
-  if (fout == NULL)
-  {
+  FILE *fout = fopen (fileName.c_str(), "w");
+  if (fout == NULL) {
     std::cerr << "Error writing UPF file " << fileName << std::endl;
     return;
   }
@@ -663,278 +599,279 @@ void PseudoClass::WriteUPF(std::string fileName)
   int N = PotentialGrid.NumPoints();
 
   // Write PP_INFO section
-  fprintf(fout, "<PP_INFO>\n");
-  fprintf(fout, "Generated using ppconvert\n");
+  fprintf (fout, "<PP_INFO>\n");
+  fprintf (fout, "Generated using ppconvert\n");
   // Get date
-  time_t now       = time(NULL);
-  struct tm& ltime = *(localtime(&now));
+  time_t now = time(NULL);
+  struct tm &ltime = *(localtime (&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((mon < 10) ? "0" : "") << mon << "/";
-  date << ((day < 10) ? "0" : "") << day << "/";
-  date << ((year < 10) ? "0" : "") << year;
-  fprintf(fout, "Author:  Kenneth P. Esler  Generation date: %s\n", date.str().c_str());
+  date << ((mon<10)  ? "0" : "") << mon << "/";
+  date << ((day<10)  ? "0" : "") << day << "/";
+  date << ((year<10) ? "0" : "") << year;
+  fprintf (fout, "Author:  Kenneth P. Esler  Generation date: %s\n",
+	   date.str().c_str());
 
 
-  fprintf(fout, "</PP_INFO>\n");
+  fprintf (fout, "</PP_INFO>\n");
 
   // Write PP_HEADER section
-  fprintf(fout, "<PP_HEADER>\n");
-  fprintf(fout, "   0                  Version Number\n");
-  fprintf(fout, "  %2s                  Element\n", ZToSymbolMap[AtomicNumber].c_str());
-  fprintf(fout, "  NC                  Norm - Conserving pseudopotential\n");
-  fprintf(fout, "   F                  Nonlinear Core Correction\n");
+  fprintf (fout, "<PP_HEADER>\n");
+  fprintf (fout, "   0                  Version Number\n");
+  fprintf (fout, "  %2s                  Element\n",
+	   ZToSymbolMap[AtomicNumber].c_str());
+  fprintf (fout, "  NC                  Norm - Conserving pseudopotential\n");
+  fprintf (fout, "   F                  Nonlinear Core Correction\n");
   std::string F_EX, F_CORR, F_XC_GRAD, F_CORR_GRAD;
-  F_EX        = "SLA";
-  F_CORR      = "PW";
-  F_XC_GRAD   = "PBE";
+  F_EX = "SLA";
+  F_CORR = "PW";
+  F_XC_GRAD = "PBE";
   F_CORR_GRAD = "PBE";
-  fprintf(fout, " %4s %4s %4s %4s  Exchange-Corelation functional\n", F_EX.c_str(), F_CORR.c_str(), F_XC_GRAD.c_str(),
-          F_CORR_GRAD.c_str());
-  fprintf(fout, "  %1.10f        Z valence\n", PseudoCharge);
-  fprintf(fout, "  %1.10f       Total energy\n", TotalEnergy);
-  fprintf(fout, "  %3.6f  %3.6f  Suggested cutoff for wfc and rho\n", 0.0, 0.0);
-  fprintf(fout, "  %ld                   Max angular momentum component\n", ChannelPotentials.size() - 1);
-  fprintf(fout, "  %4d                Number of points in mesh\n", N);
-  fprintf(fout, "  %ld   %ld               Number of Wavefunctions, Number of Projectors\n", ChannelPotentials.size(),
-          ChannelPotentials.size() - 1);
-  fprintf(fout, " WaveFunctions      nl   l   occ    \n");
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-    fprintf(fout, "                    %d%s   %d   %1.4f\n", ChannelPotentials[l].n_principal, ChannelMap[l].c_str(),
-            ChannelPotentials[l].l, ChannelPotentials[l].Occupation);
+  fprintf (fout, " %4s %4s %4s %4s  Exchange-Corelation functional\n",
+	   F_EX.c_str(), F_CORR.c_str(), F_XC_GRAD.c_str(), F_CORR_GRAD.c_str());
+  fprintf (fout, "  %1.10f        Z valence\n",
+	   PseudoCharge);
+  fprintf (fout, "  %1.10f       Total energy\n", TotalEnergy);
+  fprintf (fout, "  %3.6f  %3.6f  Suggested cutoff for wfc and rho\n",
+	   0.0, 0.0);
+  fprintf (fout, "  %ld                   Max angular momentum component\n",
+	   ChannelPotentials.size()-1);
+  fprintf (fout, "  %4d                Number of points in mesh\n",
+	   N);
+  fprintf (fout, "  %ld   %ld               Number of Wavefunctions, Number of Projectors\n", ChannelPotentials.size(), ChannelPotentials.size()-1);
+  fprintf (fout, " WaveFunctions      nl   l   occ    \n");
+  for (int l=0; l<ChannelPotentials.size(); l++)
+    fprintf (fout, "                    %d%s   %d   %1.4f\n",
+	     ChannelPotentials[l].n_principal,
+	     ChannelMap[l].c_str(),
+	     ChannelPotentials[l].l,
+	     ChannelPotentials[l].Occupation);
 
-  fprintf(fout, "</PP_HEADER>\n");
+  fprintf (fout, "</PP_HEADER>\n");
 
   // Write PP_MESH section
-  fprintf(fout, "<PP_MESH>\n");
-  fprintf(fout, "  <PP_R>\n");
-  Write4Block(fout, PotentialGrid.Points());
-  fprintf(fout, "  </PP_R>\n");
-  fprintf(fout, "  <PP_RAB>\n");
+  fprintf (fout, "<PP_MESH>\n");
+  fprintf (fout, "  <PP_R>\n");
+  Write4Block (fout, PotentialGrid.Points());
+  fprintf (fout, "  </PP_R>\n");
+  fprintf (fout, "  <PP_RAB>\n");
   std::vector<double> dr(N);
-  for (int i = 1; i < (N - 1); i++)
-    dr[i] = 0.5 * (PotentialGrid[i + 1] - PotentialGrid[i - 1]);
-  dr[0]     = 2.0 * dr[1] - dr[2];
-  dr[N - 1] = 2.0 * dr[N - 2] - dr[N - 3];
+  for (int i=1; i<(N-1); i++)
+    dr[i] = 0.5*(PotentialGrid[i+1]-PotentialGrid[i-1]);
+  dr[0]   = 2.0*dr[ 1 ]-dr[ 2 ];
+  dr[N-1] = 2.0*dr[N-2]-dr[N-3];
 
-  Write4Block(fout, dr);
-  fprintf(fout, "  </PP_RAB>\n");
-  fprintf(fout, "</PP_MESH>\n");
+  Write4Block (fout, dr);
+  fprintf (fout, "  </PP_RAB>\n");
+  fprintf (fout, "</PP_MESH>\n");
 
   // Write PP_LOCAL section
-  fprintf(fout, "<PP_LOCAL>\n");
+  fprintf (fout, "<PP_LOCAL>\n");
   std::vector<double> vloc(N);
-  for (int i = 0; i < N; i++)
-    vloc[i] = 2.0 * ChannelPotentials[LocalChannel].Vl(i); // /PotentialGrid[i];
+  for (int i=0; i<N; i++)
+    vloc[i] = 2.0*ChannelPotentials[LocalChannel].Vl(i); // /PotentialGrid[i];
   //vloc[0] = 2.0*ChannelPotentials[LocalChannel].Vl(1.0e-7)/1.0e-7;
-  Write4Block(fout, vloc);
-  fprintf(fout, "</PP_LOCAL>\n");
+  Write4Block (fout, vloc);
+  fprintf (fout, "</PP_LOCAL>\n");
 
   // Write the nonlocal section
-  fprintf(fout, "<PP_NONLOCAL>\n");
+  fprintf (fout, "<PP_NONLOCAL>\n");
   int betaNum = 1;
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-    if (l != LocalChannel)
-    {
+  for (int l=0; l<ChannelPotentials.size(); l++)
+    if (l != LocalChannel) {
       std::vector<double> beta(N);
-      for (int i = 0; i < N; i++)
-      {
-        double Vloc = ChannelPotentials[LocalChannel].Vlr(i);
-        double Vl   = ChannelPotentials[l].Vlr(i);
-        double ul   = ChannelPotentials[l].ul(i);
-        double r    = PotentialGrid[i];
-        beta[i]     = 2.0 * ul * (Vl - Vloc) / r;
-        //beta[i] = 2.0*ul*(Vl - Vloc);
-        //beta[i] = 2.0*r*ul*(Vl - Vloc);
+      for (int i=0; i<N; i++) {
+	double Vloc = ChannelPotentials[LocalChannel].Vlr(i);
+	double Vl   = ChannelPotentials[l].Vlr(i);
+	double ul   = ChannelPotentials[l].ul(i);
+	double r    = PotentialGrid[i];
+	beta[i] = 2.0*ul*(Vl - Vloc)/r;
+	//beta[i] = 2.0*ul*(Vl - Vloc);
+	//beta[i] = 2.0*r*ul*(Vl - Vloc);
       }
-      beta[0] = 2.0 * ChannelPotentials[l].ul(0.0) *
-          (ChannelPotentials[l].Vlr(1.0e-7) - ChannelPotentials[LocalChannel].Vlr(1.0e-7)) / 1.0e-7;
-      //       beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
-      // 	(ChannelPotentials[l].Vl(1.0e-7)-ChannelPotentials[LocalChannel].Vl(1.0e-7));
-      fprintf(fout, "  <PP_BETA>\n");
-      fprintf(fout, "    %d %d             Beta L\n", betaNum, l);
-      fprintf(fout, "    %d  \n", N);
-      Write4Block(fout, beta, 4);
-      fprintf(fout, "  </PP_BETA>\n");
+      beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
+ 	(ChannelPotentials[l].Vlr(1.0e-7)-ChannelPotentials[LocalChannel].Vlr(1.0e-7))/1.0e-7;
+//       beta[0] = 2.0*ChannelPotentials[l].ul(0.0)*
+// 	(ChannelPotentials[l].Vl(1.0e-7)-ChannelPotentials[LocalChannel].Vl(1.0e-7));
+      fprintf (fout, "  <PP_BETA>\n");
+      fprintf (fout, "    %d %d             Beta L\n", betaNum, l);
+      fprintf (fout, "    %d  \n", N);
+      Write4Block (fout, beta, 4);
+      fprintf (fout, "  </PP_BETA>\n");
       betaNum++;
     }
   // Write D_ij matrix
-  fprintf(fout, "  <PP_DIJ>\n");
-  fprintf(fout, "    %ld         Number of nonzero Dij\n", ChannelPotentials.size() - 1);
+  fprintf (fout, "  <PP_DIJ>\n");
+  fprintf (fout, "    %ld         Number of nonzero Dij\n",
+	   ChannelPotentials.size()-1);
   betaNum = 1;
   // Compute D_ij matrix.  In our case, with single projectors, D_ij
   // is diagonal.  The elements are
   // D_ll = 1.0/<u_l |Vl - Vloc | u_l>
   // We will numerically integrate with Simpson's rule
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-    if (l != LocalChannel)
-    {
-      const int M   = 100000;
+  for (int l=0; l<ChannelPotentials.size(); l++)
+    if (l != LocalChannel) {
+      const int M = 100000;
       double DijInv = 0.0;
-      double norm   = 0.0;
-      double dr     = PotentialGrid[N - 1] / (double)(M);
-      double third  = 1.0 / 3.0;
+      double norm = 0.0;
+      double dr = PotentialGrid[N-1]/(double)(M);
+      double third = 1.0/3.0;
       double prefactor;
       double r = 1.0e-8;
-      for (int i = 0; i <= M; i++)
-      {
-        double Vl   = ChannelPotentials[l].Vlr(r) / r;
-        double Vloc = ChannelPotentials[LocalChannel].Vlr(r) / r;
-        double u    = ChannelPotentials[l].ul(r);
-        // Prefactors for Simpsons's rule
-        if ((i == 0) || (i == M))
-          prefactor = third;
-        else if ((i & 1) == 1)
-          prefactor = 4.0 * third;
-        else
-          prefactor = 2.0 * third;
-        DijInv += prefactor * dr * u * u * 2.0 * (Vl - Vloc);
-        norm += prefactor * u * u * dr;
-        r += dr;
+      for (int i=0; i<=M; i++) {
+	double Vl   = ChannelPotentials[l].Vlr(r)/r;
+	double Vloc = ChannelPotentials[LocalChannel].Vlr(r)/r;
+	double u = ChannelPotentials[l].ul(r);
+	// Prefactors for Simpsons's rule
+	if ((i==0) || (i==M))
+	  prefactor = third;
+	else if ((i&1)==1)
+	  prefactor = 4.0* third;
+	else
+	  prefactor = 2.0*third;
+	DijInv += prefactor*dr *u * u * 2.0 * (Vl - Vloc);
+	norm += prefactor*u*u*dr;
+	r += dr;
       }
-      double Dij = 1.0 / DijInv;
-      fprintf(fout, "    %d %d  %1.20e\n", betaNum, betaNum, Dij);
-      fprintf(stderr, "l = %d, betaNum = %d, norm = %1.10e  Dij = %1.10e\n", l, betaNum, norm, Dij);
+      double Dij = 1.0/DijInv;
+      fprintf (fout, "    %d %d  %1.20e\n", betaNum, betaNum, Dij);
+      fprintf (stderr, "l = %d, betaNum = %d, norm = %1.10e  Dij = %1.10e\n",
+	       l, betaNum, norm, Dij);
       betaNum++;
     }
-  fprintf(fout, "  </PP_DIJ>\n");
-  fprintf(fout, "</PP_NONLOCAL>\n");
+  fprintf (fout, "  </PP_DIJ>\n");
+  fprintf (fout, "</PP_NONLOCAL>\n");
 
   // Write PP_PSWFC section
-  fprintf(fout, "<PP_PSWFC>\n");
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
-    ChannelPotentialClass& pot = ChannelPotentials[l];
-    fprintf(fout, "%d%s    %d  %6.4f          Wavefunction\n", pot.n_principal, ChannelMap[l].c_str(), l,
-            pot.Occupation);
+  fprintf (fout, "<PP_PSWFC>\n");
+  for (int l=0; l<ChannelPotentials.size(); l++) {
+    ChannelPotentialClass &pot = ChannelPotentials[l];
+    fprintf (fout, "%d%s    %d  %6.4f          Wavefunction\n",
+	     pot.n_principal, ChannelMap[l].c_str(), l, pot.Occupation);
     std::vector<double> u(N);
-    for (int i = 0; i < N; i++)
+    for (int i=0; i<N; i++)
       u[i] = pot.ul(i);
-    Write4Block(fout, u);
+    Write4Block (fout, u);
   }
-  fprintf(fout, "</PP_PSWFC>\n");
+  fprintf (fout, "</PP_PSWFC>\n");
 
   // Write PP_RHOATOM section
-  fprintf(fout, "<PP_RHOATOM>\n");
+  fprintf (fout, "<PP_RHOATOM>\n");
   std::vector<double> rho_at(N);
-  for (int i = 0; i < N; i++)
-  {
+  for (int i=0; i<N; i++) {
     if (RhoAtom.Initialized)
-      rho_at[i] = RhoAtom(i) * PotentialGrid[i] * PotentialGrid[i];
-    else
-    {
+      rho_at[i] = RhoAtom(i)*PotentialGrid[i]*PotentialGrid[i];
+    else {
       rho_at[i] = 0.0;
-      for (int l = 0; l < ChannelPotentials.size(); l++)
-      {
-        ChannelPotentialClass& pot = ChannelPotentials[l];
-        double u                   = pot.ul(i);
-        rho_at[i] += pot.Occupation * u * u;
+      for (int l=0; l<ChannelPotentials.size(); l++) {
+	ChannelPotentialClass &pot = ChannelPotentials[l];
+	double u = pot.ul(i);
+	rho_at[i] += pot.Occupation * u*u;
       }
     }
   }
-  Write4Block(fout, rho_at);
+  Write4Block (fout, rho_at);
 
-  fprintf(fout, "</PP_RHOATOM>\n");
+  fprintf (fout, "</PP_RHOATOM>\n");
 
   // Close the file
-  fclose(fout);
+  fclose (fout);
 }
 
 
-void PseudoClass::WriteFHI(std::string fileName)
+void
+PseudoClass::WriteFHI (std::string fileName)
 {
-  const double amesh  = 1.013084867359809;
+  const double amesh =  1.013084867359809;
   const int numPoints = 1118;
 
 
-  FILE* fout = fopen(fileName.c_str(), "w");
-  assert(fout != NULL);
+  FILE *fout = fopen (fileName.c_str(), "w");
+  assert (fout != NULL);
   // Write ABINIT header
-  fprintf(fout, "Written by ppconvert:  %s psuedopotential\n", ZToSymbolMap[AtomicNumber].c_str());
-  time_t now       = time(NULL);
-  struct tm& ltime = *(localtime(&now));
+  fprintf (fout, "Written by ppconvert:  %s psuedopotential\n",
+	   ZToSymbolMap[AtomicNumber].c_str());
+  time_t now = time(NULL);
+  struct tm &ltime = *(localtime (&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((year < 10) ? "0" : "") << year;
-  date << ((mon < 10) ? "0" : "") << mon;
-  date << ((day < 10) ? "0" : "") << day;
+  date << ((year<10) ? "0" : "") << year;
+  date << ((mon<10)  ? "0" : "") << mon;
+  date << ((day<10)  ? "0" : "") << day;
 
-  fprintf(fout,
-          "%9.5f %9.5f %s"
-          "                    zatom, zion, pspdat\n",
-          (double)AtomicNumber, PseudoCharge, date.str().c_str());
+  fprintf (fout, "%9.5f %9.5f %s"
+	   "                    zatom, zion, pspdat\n", (double)AtomicNumber,
+	   PseudoCharge, date.str().c_str());
 
-  fprintf(fout,
-          "    6   7  %ld  %d  %d  0.0000     "
-          "pspcod,pspxc,lmax,lloc,mmax,r2well\n",
-          ChannelPotentials.size() - 1, LocalChannel, numPoints);
-  fprintf(fout,
-          "   0.00000   0.00000   0.00000                  "
-          "rchrg,fchrg,qchrg\n");
-  fprintf(fout,
-          "5 --- reserved for future features\n"
-          "6 --- reserved for future features\n"
-          "7 --- Here follows the cpi file in the fhi98pp format -\n");
+  fprintf (fout, "    6   7  %ld  %d  %d  0.0000     "
+	   "pspcod,pspxc,lmax,lloc,mmax,r2well\n",
+	   ChannelPotentials.size()-1, LocalChannel, numPoints);
+  fprintf (fout, "   0.00000   0.00000   0.00000                  "
+	   "rchrg,fchrg,qchrg\n");
+  fprintf (fout, "5 --- reserved for future features\n"
+	   "6 --- reserved for future features\n"
+	   "7 --- Here follows the cpi file in the fhi98pp format -\n");
 
   // Write FHI file proper
-  fprintf(fout, "%d %ld\n", (int)round(PseudoCharge), ChannelPotentials.size());
-  for (int i = 0; i < 10; i++)
-    fprintf(fout, "0.0 0.0 0.0\n");
+  fprintf (fout, "%d %ld\n", (int)round(PseudoCharge),
+	   ChannelPotentials.size());
+  for (int i=0; i<10; i++)
+    fprintf (fout, "0.0 0.0 0.0\n");
 
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
-    fprintf(fout, "%d %1.18f\n", numPoints, amesh);
-    double r   = 5.848035476425733e-05;
+  for (int l=0; l<ChannelPotentials.size(); l++) {
+    fprintf (fout, "%d %1.18f\n", numPoints, amesh);
+    double r = 5.848035476425733e-05;
     double nrm = 0.0;
-    for (int i = 0; i < numPoints; i++)
-    {
-      double Vl = ChannelPotentials[l].Vlr(r) / r;
+    for (int i=0; i<numPoints; i++) {
+      double Vl = ChannelPotentials[l].Vlr(r)/r;
       double ul = ChannelPotentials[l].ul(r);
-      nrm += 0.5 * r * (amesh - 1.0 / amesh) * ul * ul;
+      nrm += 0.5*r*(amesh-1.0/amesh)*ul*ul;
 
-      fprintf(fout, "%5d  %20.16e %20.16e %20.16e\n", i + 1, r, ul, Vl);
+      fprintf (fout, "%5d  %20.16e %20.16e %20.16e\n",
+	       i+1, r, ul, Vl);
       r *= amesh;
     }
-    fprintf(stderr, "Norm = %1.8f\n", nrm);
+    fprintf (stderr, "Norm = %1.8f\n", nrm);
   }
-  fclose(fout);
+  fclose (fout);
 }
 
 
-void PseudoClass::WriteABINIT(std::string fileName)
+void
+PseudoClass::WriteABINIT (std::string fileName)
 {
   if (fileName == "")
     fileName = ZToSymbolMap[AtomicNumber] + ".psp";
 
-  FILE* fout = fopen(fileName.c_str(), "w");
-  assert(fout != NULL);
+  FILE *fout = fopen (fileName.c_str(), "w");
+  assert (fout != NULL);
 
-  time_t now       = time(NULL);
-  struct tm& ltime = *(localtime(&now));
+  time_t now = time(NULL);
+  struct tm &ltime = *(localtime (&now));
   std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
-  date << ((year < 10) ? "0" : "") << year;
-  date << ((mon < 10) ? "0" : "") << mon;
-  date << ((day < 10) ? "0" : "") << day;
+  date << ((year<10) ? "0" : "") << year;
+  date << ((mon<10)  ? "0" : "") << mon;
+  date << ((day<10)  ? "0" : "")  << day;
 
-  fprintf(fout, "%s  %s", ZToSymbolMap[AtomicNumber].c_str(), asctime(&ltime));
-  fprintf(fout,
-          "%9.5f %9.5f %s"
-          "                    zatom, zion, pspdat\n",
-          (double)AtomicNumber, PseudoCharge, date.str().c_str());
+  fprintf (fout, "%s  %s", ZToSymbolMap[AtomicNumber].c_str(),
+	   asctime(&ltime));
+  fprintf (fout, "%9.5f %9.5f %s"
+	   "                    zatom, zion, pspdat\n", (double)AtomicNumber,
+	   PseudoCharge, date.str().c_str());
   const int pspcod = 1;
   const int pspxc  = 0;
-  const int lmax   = ChannelPotentials.size() - 1;
+  const int lmax   = ChannelPotentials.size()-1;
   // HACK HACK HAK
-  const int lloc = LocalChannel;
-  const int mmax = 2001;
-  double r2well  = 0.0;
+  const int lloc   = LocalChannel;
+  const int mmax  = 2001;
+  double r2well = 0.0;
   // The following are informational only
   const double e99    = 0.0;
   const double e999   = 0.0;
@@ -946,203 +883,193 @@ void PseudoClass::WriteABINIT(std::string fileName)
   const double rchrg  = 1.0;
   const double qchrg  = 0.0;
 
-  fprintf(fout,
-          "%d   %d   %d   %d   %d   %8.5f"
-          "              pspcod,pspxc,lmax,lloc,mmax,r2well\n",
-          pspcod, pspxc, lmax, lloc, mmax, r2well);
+  fprintf (fout, "%d   %d   %d   %d   %d   %8.5f"
+	   "              pspcod,pspxc,lmax,lloc,mmax,r2well\n",
+	   pspcod, pspxc, lmax, lloc, mmax, r2well);
 
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
+  for (int l=0; l<ChannelPotentials.size(); l++) {
     // The local channel needs no projector
     int nproj = (l == lloc) ? 0 : 1;
-    fprintf(fout,
-            "%d %5.8f %5.8f %d %5.8f"
-            "          l,e99.0,e99.9,nproj,rcpsp\n",
-            l, e99, e999, nproj, ChannelPotentials[l].Cutoff);
-    fprintf(fout,
-            "%14.10f %14.10f %14.10f %14.10f"
-            "  rms,ekb1,ekb2,epsatm\n",
-            rms, ekb1, ekb2, epsatm);
+    fprintf (fout, "%d %5.8f %5.8f %d %5.8f"
+	     "          l,e99.0,e99.9,nproj,rcpsp\n",
+	     l, e99, e999, nproj, ChannelPotentials[l].Cutoff);
+    fprintf (fout, "%14.10f %14.10f %14.10f %14.10f"
+	     "  rms,ekb1,ekb2,epsatm\n", rms, ekb1, ekb2, epsatm);
   }
-  fprintf(fout,
-          "%8.5f %8.5f %8.5f"
-          "                    rchrg,fchrg,qchrg\n",
-          rchrg, fchrg, qchrg);
+  fprintf (fout, "%8.5f %8.5f %8.5f"
+	   "                    rchrg,fchrg,qchrg\n", rchrg, fchrg, qchrg);
 
   // Write out potentials
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
-    fprintf(fout, "%d = l for CASINO pseudopotential\n", l);
-    for (int i = 0; i < mmax; i++)
-    {
-      double x = (double)i / (double)(mmax - 1);
+  for (int l=0; l<ChannelPotentials.size(); l++) {
+    fprintf (fout, "%d = l for CASINO pseudopotential\n", l);
+    for (int i=0; i<mmax; i++) {
+      double x = (double)i/(double)(mmax-1);
       x += 0.01;
-      double r = 100.0 * x * x * x * x * x - 1.0e-8;
+      double r = 100.0*x*x*x*x*x - 1.0e-8;
       double Vl;
       if (r >= ChannelPotentials[l].Vl.grid.End())
-        Vl = -1.0 * PseudoCharge / r;
+	Vl = -1.0*PseudoCharge/r;
       else
-        Vl = ChannelPotentials[l].Vl(r); // /r;
+	Vl = ChannelPotentials[l].Vl(r); // /r;
       double Vlold = Vl;
-      Vl           = ChannelPotentials[l].Vlr(r) / r;
+      Vl = ChannelPotentials[l].Vlr(r)/r;
       if (i == 0)
-        Vl = ChannelPotentials[l].Vl(0.0);
+	Vl = ChannelPotentials[l].Vl(0.0);
       // fprintf (stderr, "r = %1.10f  Interp diff = %1.8e\n", r, Vl-Vlold);
-      fprintf(fout, "%23.16e ", Vl);
-      if ((i % 3) == 2)
-        fprintf(fout, "\n");
+      fprintf (fout, "%23.16e ", Vl);
+      if ((i%3)==2)
+	fprintf (fout, "\n");
     }
   }
   // Now write out radial wave functions
-  for (int l = 0; l < ChannelPotentials.size(); l++)
-  {
-    fprintf(fout, "%d = l for CASINO wave function\n", l);
-    for (int i = 0; i < mmax; i++)
-    {
-      double x = (double)i / (double)(mmax - 1);
-      x += 0.01;
-      double r = 100.0 * x * x * x * x * x - 1.0e-8;
-      double ul;
-      double rend = ChannelPotentials[l].ul.grid.End();
-      if (r >= rend)
-      {
-        int i = ChannelPotentials[l].ul.grid.NumPoints();
-        while (fabs(ChannelPotentials[l].ul(i)) == 0.0)
-          i--;
-        double r2    = ChannelPotentials[l].ul.grid[i];
-        double r1    = ChannelPotentials[l].ul.grid[i - 10];
-        double u2    = ChannelPotentials[l].ul(i);
-        double u1    = ChannelPotentials[l].ul(i - 10);
-        double alpha = log(u1 / u2) / (r2 - r1);
-        // rend = min (rend, 60.0);
-        // double uend = ChannelPotentials[l].ul(rend);
-        // double alpha = log (ChannelPotentials[l].ul(rend-1.0)/uend);
-        //cerr << "alpha = " << alpha << " rend = " << r2 << " u2 = " << u2 << endl;
-        // ul = uend * exp(-alpha*(r-rend));
-        ul = u2 * exp(-alpha * (r - r2));
+  for (int l=0; l<ChannelPotentials.size(); l++) {
+      fprintf (fout, "%d = l for CASINO wave function\n", l);
+      for (int i=0; i<mmax; i++) {
+	double x = (double)i/(double)(mmax-1);
+	x += 0.01;
+	double r = 100.0*x*x*x*x*x - 1.0e-8;
+	double ul;
+	double rend = ChannelPotentials[l].ul.grid.End();
+	if (r >= rend) {
+	  int i=ChannelPotentials[l].ul.grid.NumPoints();
+	  while (fabs(ChannelPotentials[l].ul(i)) == 0.0) i--;
+	  double r2 = ChannelPotentials[l].ul.grid[i];
+	  double r1 = ChannelPotentials[l].ul.grid[i-10];
+	  double u2 = ChannelPotentials[l].ul(i);
+	  double u1 = ChannelPotentials[l].ul(i-10);
+	  double alpha = log(u1/u2)/(r2-r1);
+	  // rend = min (rend, 60.0);
+	  // double uend = ChannelPotentials[l].ul(rend);
+	  // double alpha = log (ChannelPotentials[l].ul(rend-1.0)/uend);
+	  //cerr << "alpha = " << alpha << " rend = " << r2 << " u2 = " << u2 << endl;
+	  // ul = uend * exp(-alpha*(r-rend));
+	  ul = u2 * exp(-alpha*(r - r2));
+	}
+	else
+	  ul= ChannelPotentials[l].ul(r);
+	fprintf (fout, "%23.16e ", ul);
+	if ((i%3)==2)
+	  fprintf (fout, "\n");
       }
-      else
-        ul = ChannelPotentials[l].ul(r);
-      fprintf(fout, "%23.16e ", ul);
-      if ((i % 3) == 2)
-        fprintf(fout, "\n");
-    }
   }
 
-  fclose(fout);
+  fclose (fout);
 }
 
-void PseudoClass::WriteASCII()
+void
+PseudoClass::WriteASCII()
 {
-  FILE* fout = fopen("pp.dat", "w");
-  for (int i = 1; i < PotentialGrid.NumPoints(); i++)
-  {
-    double r = PotentialGrid[i];
-    fprintf(fout, "%24.16e ", r);
-    for (int l = 0; l < ChannelPotentials.size(); l++)
-      fprintf(fout, "%24.16e ", ChannelPotentials[l].Vl(r)); // /r);
-    fprintf(fout, "\n");
+  FILE *fout = fopen ("pp.dat", "w");
+  for (int i=1; i<PotentialGrid.NumPoints(); i++) {
+    double r= PotentialGrid[i];
+    fprintf (fout, "%24.16e ", r);
+    for (int l=0; l<ChannelPotentials.size(); l++)
+      fprintf (fout, "%24.16e ", ChannelPotentials[l].Vl(r));// /r);
+    fprintf (fout, "\n");
   }
-  fclose(fout);
+  fclose (fout);
 
-  fout = fopen("ul.dat", "w");
-  for (int i = 1; i < PotentialGrid.NumPoints(); i++)
-  {
-    double r = PotentialGrid[i];
-    fprintf(fout, "%24.16e ", r);
-    for (int l = 0; l < ChannelPotentials.size(); l++)
-      fprintf(fout, "%24.16e ", ChannelPotentials[l].ul(r)); // /r);
-    fprintf(fout, "\n");
+  fout = fopen ("ul.dat", "w");
+  for (int i=1; i<PotentialGrid.NumPoints(); i++) {
+    double r= PotentialGrid[i];
+    fprintf (fout, "%24.16e ", r);
+    for (int l=0; l<ChannelPotentials.size(); l++)
+      fprintf (fout, "%24.16e ", ChannelPotentials[l].ul(r));// /r);
+    fprintf (fout, "\n");
   }
-  fclose(fout);
+  fclose (fout);
+
+
 }
 
-bool PseudoClass::ReadBFD_PP(std::string fileName)
+bool
+PseudoClass::ReadBFD_PP (std::string fileName)
 {
   MemParserClass parser;
-  assert(parser.OpenFile(fileName));
+  assert(parser.OpenFile (fileName));
 
-  assert(parser.FindToken("Element Symbol:"));
+  assert (parser.FindToken ("Element Symbol:"));
   std::string symbol;
-  assert(parser.ReadWord(symbol));
+  assert (parser.ReadWord(symbol));
   AtomicNumber = SymbolToZMap[symbol];
-  std::cerr << "Reading element " << symbol << ", which has Z=" << AtomicNumber << std::endl;
+  std::cerr << "Reading element " << symbol
+       << ", which has Z=" << AtomicNumber << std::endl;
   int numProtons, numProjectors;
-  assert(parser.FindToken("Number of replaced protons:"));
-  assert(parser.ReadInt(numProtons));
-  assert(parser.FindToken("Number of projectors:"));
-  assert(parser.ReadInt(numProjectors));
-  ChannelPotentials.resize(numProjectors + 1);
-  assert(parser.FindToken("Local component:"));
-  assert(parser.FindToken("Exp."));
+  assert (parser.FindToken ("Number of replaced protons:"));
+  assert (parser.ReadInt (numProtons));
+  assert (parser.FindToken ("Number of projectors:"));
+  assert (parser.ReadInt (numProjectors));
+  ChannelPotentials.resize(numProjectors+1);
+  assert (parser.FindToken ("Local component:"));
+  assert (parser.FindToken ("Exp."));
   double c0, c1, c2, exp0, exp1, exp2;
   int power;
-  assert(parser.ReadDouble(c0));
+  assert (parser.ReadDouble(c0));
   PseudoCharge = c0;
-  assert(parser.ReadInt(power));
-  assert(power == -1);
-  assert(parser.ReadDouble(exp0));
+  assert (parser.ReadInt (power));
+  assert (power == -1);
+  assert (parser.ReadDouble(exp0));
 
-  assert(parser.ReadDouble(c1));
-  assert(parser.ReadInt(power));
-  assert(power == 1);
-  assert(parser.ReadDouble(exp1));
+  assert (parser.ReadDouble(c1));
+  assert (parser.ReadInt (power));
+  assert (power == 1);
+  assert (parser.ReadDouble(exp1));
 
-  assert(parser.ReadDouble(c2));
-  assert(parser.ReadInt(power));
-  assert(power == 0);
-  assert(parser.ReadDouble(exp2));
+  assert (parser.ReadDouble(c2));
+  assert (parser.ReadInt (power));
+  assert (power == 0);
+  assert (parser.ReadDouble(exp2));
 
   // Create local channel spline
   std::vector<double> gridPoints, Vlocal, Vlocalr;
-  FILE* fout = fopen("Vlocal.dat", "w");
-  for (double r = 1.0e-8; r < 150.0; r += 0.01)
-  {
-    gridPoints.push_back(r);
-    double Vloc  = (c0 / r) * (expm1(-exp0 * r * r)) + c1 * r * exp(-exp1 * r * r) + c2 * exp(-exp2 * r * r);
-    double Vlocr = (c0) * (expm1(-exp0 * r * r)) + c1 * r * r * exp(-exp1 * r * r) + c2 * r * exp(-exp2 * r * r);
+  FILE *fout = fopen ("Vlocal.dat", "w");
+  for (double r=1.0e-8; r<150.0; r+=0.01) {
+    gridPoints.push_back (r);
+    double Vloc = (c0/r)*(expm1(-exp0*r*r)) +
+      c1*r*exp(-exp1*r*r) +
+      c2*exp(-exp2*r*r);
+    double Vlocr = (c0)*(expm1(-exp0*r*r)) +
+      c1*r*r*exp(-exp1*r*r) +
+      c2*r*exp(-exp2*r*r);
     Vlocal.push_back(Vloc);
     Vlocalr.push_back(Vlocr);
-    fprintf(fout, "%1.16e %1.16e %1.16e\n", r, Vloc, Vlocr);
+    fprintf (fout, "%1.16e %1.16e %1.16e\n", r, Vloc, Vlocr);
   }
-  fclose(fout);
+  fclose (fout);
   int local = numProjectors;
-  if (LocalChannel < 0)
-    LocalChannel = local;
-  PotentialGrid.Init(gridPoints);
+  if (LocalChannel<0) LocalChannel = local;
+  PotentialGrid.Init (gridPoints);
   ChannelPotentials[local].Vl.Init(PotentialGrid, Vlocal);
   ChannelPotentials[local].Vlr.Init(PotentialGrid, Vlocalr);
   ChannelPotentials[local].l = local;
 
   // Now read nonlocal component
-  assert(parser.FindToken("Non-local component:"));
-  assert(parser.FindToken("Proj."));
-  for (int l = 0; l < numProjectors; l++)
-  {
+  assert (parser.FindToken ("Non-local component:"));
+  assert (parser.FindToken ("Proj."));
+  for (int l=0; l<numProjectors; l++) {
     char fname[100];
-    snprintf(fname, 100, "V_%d.dat", l);
-    FILE* fout = fopen(fname, "w");
+    snprintf (fname, 100, "V_%d.dat", l);
+    FILE *fout = fopen (fname, "w");
     double c0, exp0;
     int power, channel;
-    assert(parser.ReadDouble(c0));
-    assert(parser.ReadInt(power));
-    assert(power == 0);
-    assert(parser.ReadDouble(exp0));
-    assert(parser.FindToken("|"));
-    assert(parser.ReadInt(channel));
-    assert(channel == l);
-    assert(parser.FindToken("|"));
+    assert (parser.ReadDouble (c0));
+    assert (parser.ReadInt (power));
+    assert (power == 0);
+    assert (parser.ReadDouble (exp0));
+    assert (parser.FindToken ("|"));
+    assert (parser.ReadInt(channel));
+    assert (channel == l);
+    assert (parser.FindToken("|"));
     std::vector<double> Vl(gridPoints.size()), Vlr(gridPoints.size());
-    for (int i = 0; i < gridPoints.size(); i++)
-    {
+    for (int i=0; i<gridPoints.size(); i++) {
       double r = gridPoints[i];
-      Vl[i]    = Vlocal[i] + c0 * exp(-exp0 * r * r);
-      Vlr[i]   = Vlocalr[i] + r * c0 * exp(-exp0 * r * r);
-      fprintf(fout, "%1.16e %1.16e %1.16e\n", r, Vl[i], Vlr[i]);
+      Vl[i]  =  Vlocal[i] +   c0*exp(-exp0*r*r);
+      Vlr[i] = Vlocalr[i] + r*c0*exp(-exp0*r*r);
+      fprintf (fout, "%1.16e %1.16e %1.16e\n", r, Vl[i], Vlr[i]);
     }
-    fclose(fout);
-    ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
-    ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
+    fclose (fout);
+    ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
+    ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
     ChannelPotentials[l].l = l;
   }
 
@@ -1152,98 +1079,93 @@ bool PseudoClass::ReadBFD_PP(std::string fileName)
 }
 
 
-bool PseudoClass::ReadFHI_PP(std::string fileName)
+bool
+PseudoClass::ReadFHI_PP (std::string fileName)
 {
   MemParserClass parser;
-  if (!parser.OpenFile(fileName))
-  {
+  if (!parser.OpenFile (fileName)) {
     std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
   std::string temp;
   // Read top comment line
-  assert(parser.ReadLine(temp));
+  assert (parser.ReadLine(temp));
   double atomCharge;
-  assert(parser.ReadDouble(atomCharge));
+  assert (parser.ReadDouble(atomCharge));
   AtomicNumber = (int)round(atomCharge);
-  assert(parser.ReadDouble(PseudoCharge));
+  assert (parser.ReadDouble(PseudoCharge));
   int date, pspcode, pspxc, lmax, lloc, mmax;
-  assert(parser.ReadInt(date));
-  assert(parser.ReadLine(temp));
-  assert(parser.ReadInt(pspcode));
-  assert(parser.ReadInt(pspxc));
-  assert(parser.ReadInt(lmax));
-  assert(parser.ReadInt(LocalChannel));
-  assert(parser.ReadInt(mmax));
+  assert (parser.ReadInt(date));
+  assert (parser.ReadLine(temp));
+  assert (parser.ReadInt(pspcode));
+  assert (parser.ReadInt(pspxc));
+  assert (parser.ReadInt(lmax));
+  assert (parser.ReadInt(LocalChannel));
+  assert (parser.ReadInt(mmax));
   // Read the rest of the line and skip the next 4
-  for (int i = 0; i < 5; i++)
-    assert(parser.FindToken("\n"));
+  for (int i=0; i<5; i++)
+    assert (parser.FindToken("\n"));
   // Now we are in the FHI file proper
   double chrg;
-  assert(parser.ReadDouble(chrg));
-  if (fabs(chrg - PseudoCharge) > 1.0e-10)
-  {
+  assert (parser.ReadDouble(chrg));
+  if(fabs(chrg-PseudoCharge) > 1.0e-10) {
     std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
     std::cerr << "chrg = " << chrg << std::endl;
   }
 
   // Read number of channels and resize
   int numChannels;
-  assert(parser.ReadInt(numChannels));
+  assert (parser.ReadInt(numChannels));
   ChannelPotentials.resize(numChannels);
 
   // Skip the next 10 lines
-  for (int i = 0; i < 11; i++)
-    assert(parser.FindToken("\n"));
+  for (int i=0; i<11; i++)
+    assert (parser.FindToken("\n"));
 
   // Read the number of grid points
-  for (int l = 0; l < numChannels; l++)
-  {
+  for (int l=0; l<numChannels; l++) {
     int numPoints;
     double a_ratio;
-    assert(parser.ReadInt(numPoints));
-    assert(parser.ReadDouble(a_ratio));
-    std::vector<double> points(numPoints), ul(numPoints), Vl(numPoints), Vlr(numPoints);
-    for (int m = 0; m < numPoints; m++)
-    {
+    assert (parser.ReadInt(numPoints));
+    assert (parser.ReadDouble(a_ratio));
+    std::vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
+      Vlr(numPoints);
+    for (int m=0; m<numPoints; m++) {
       int mtest;
-      assert(parser.ReadInt(mtest));
-      assert(mtest == (m + 1));
-      assert(parser.ReadDouble(points[m]));
-      assert(parser.ReadDouble(ul[m]));
-      assert(parser.ReadDouble(Vl[m]));
-      Vlr[m] = Vl[m] * points[m];
+      assert (parser.ReadInt(mtest));
+      assert (mtest == (m+1));
+      assert (parser.ReadDouble(points[m]));
+      assert (parser.ReadDouble(ul[m]));
+      assert (parser.ReadDouble(Vl[m]));
+      Vlr[m] = Vl[m]*points[m];
     }
-    PotentialGrid.Init(points);
-    ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
-    ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
-    ChannelPotentials[l].ul.Init(PotentialGrid, ul);
-    ChannelPotentials[l].l            = l;
-    ChannelPotentials[l].n_principal  = -1;
-    ChannelPotentials[l].Cutoff       = 0.0;
+    PotentialGrid.Init (points);
+    ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
+    ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
+    ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
+    ChannelPotentials[l].l = l;
+    ChannelPotentials[l].n_principal = -1;
+    ChannelPotentials[l].Cutoff = 0.0;
     ChannelPotentials[l].HasProjector = true;
   }
   // Now, figure out what rcut should be
   double rmax = PotentialGrid.End();
-  int n       = PotentialGrid.NumPoints() - 1;
-  bool diff   = false;
-  while ((n > 0) && !diff)
-  {
+  int n = PotentialGrid.NumPoints()-1;
+  bool diff = false;
+  while ((n>0) && !diff) {
     double r = PotentialGrid[n];
-    rmax     = r;
-    for (int l1 = 0; l1 < numChannels; l1++)
-    {
+    rmax = r;
+    for (int l1=0; l1<numChannels; l1++) {
       double Vl1 = ChannelPotentials[l1].Vl(r);
-      for (int l2 = l1 + 1; l2 < numChannels; l2++)
-      {
-        double Vl2 = ChannelPotentials[l2].Vl(r);
-        if (fabs(Vl1 - Vl2) > 1.0e-5)
-          diff = true;
+      for (int l2=l1+1; l2<numChannels; l2++) {
+	double Vl2 = ChannelPotentials[l2].Vl(r);
+	if (fabs(Vl1-Vl2) > 1.0e-5)
+	  diff = true;
       }
     }
     n--;
   }
-  for (int l = 0; l < ChannelPotentials.size(); l++)
+  for (int l=0; l<ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rmax;
 
   parser.CloseFile();
@@ -1256,42 +1178,41 @@ public:
   int l;
   std::vector<double> beta, u, V;
   KBprojector() {}
-  KBprojector(int l_, std::vector<double> beta_) : l(l_), beta(beta_) {}
+  KBprojector(int l_, std::vector<double> beta_) :
+    l(l_), beta(beta_) {}
 };
 
-bool PseudoClass::ReadUPF_PP(std::string fileName)
+bool
+PseudoClass::ReadUPF_PP (std::string fileName)
 {
   MemParserClass parser;
-  if (!parser.OpenFile(fileName))
-  {
+  if (!parser.OpenFile (fileName)) {
     std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
   std::string temp;
 
-  assert(parser.FindToken("<PP_HEADER>"));
-  assert(parser.NextLine());
+  assert(parser.FindToken("<PP_HEADER>")); assert(parser.NextLine());
   // Skip version number
   assert(parser.NextLine());
   std::string element, ppType, coreCorrection;
-  assert(parser.ReadWord(element));
-  assert(parser.NextLine());
+  assert(parser.ReadWord(element));  assert(parser.NextLine());
   assert(SymbolToZMap.find(element) != SymbolToZMap.end());
   AtomicNumber = SymbolToZMap[element];
   //  cerr << "Element = \"" << element << "\"\n";
 
   assert(parser.ReadWord(ppType));
-  if (ppType != "NC")
-  {
-    std::cerr << "Psuedopotential type \"" << ppType << "\" is not norm-conserving.\n";
+  if (ppType != "NC") {
+    std::cerr << "Psuedopotential type \"" << ppType
+	 << "\" is not norm-conserving.\n";
     abort();
   }
-  assert(parser.NextLine());
-  assert(parser.ReadWord(coreCorrection));
-  assert(parser.NextLine());
-  if (coreCorrection != "F" && coreCorrection != "f" && coreCorrection != "false" && coreCorrection != "False" &&
-      coreCorrection != ".F." && coreCorrection != ".f" && coreCorrection != "FALSE")
-  {
+  assert (parser.NextLine());
+  assert (parser.ReadWord(coreCorrection)); assert(parser.NextLine());
+  if (coreCorrection != "F" && coreCorrection != "f" &&
+      coreCorrection != "false" && coreCorrection != "False" &&
+      coreCorrection != ".F." && coreCorrection != ".f" &&
+      coreCorrection != "FALSE") {
     std::cerr << "It appears that a nonlinear core correction was used.  Cannot convert PP.\n";
     abort();
   }
@@ -1309,45 +1230,42 @@ bool PseudoClass::ReadUPF_PP(std::string fileName)
   assert(parser.NextLine());
 
   int numPoints;
-  assert(parser.ReadInt(numPoints));
-  assert(parser.NextLine());
+  assert(parser.ReadInt(numPoints)); assert(parser.NextLine());
   int numWF, numProj;
-  assert(parser.ReadInt(numWF));
-  assert(parser.ReadInt(numProj));
-  int numChannels = numProj + 1;
+  assert (parser.ReadInt(numWF)); assert(parser.ReadInt(numProj));
+  int numChannels = numProj+1;
 
   ChannelPotentials.resize(numChannels);
 
 
   assert(parser.FindToken("Wavefunctions"));
-  //   for (int i=0; i<numWF; i++) {
-  //     assert(parser.FindToken("NL"));
-  //     int l;
-  //     double occ;
-  //     assert(parser.ReadInt(l));
-  //     assert(parser.ReadDouble(occ));
-  //   }
+//   for (int i=0; i<numWF; i++) {
+//     assert(parser.FindToken("NL"));
+//     int l;
+//     double occ;
+//     assert(parser.ReadInt(l));
+//     assert(parser.ReadDouble(occ));
+//   }
   assert(parser.FindToken("</PP_HEADER>"));
 
   assert(parser.FindToken("<PP_MESH>"));
   assert(parser.FindToken("<PP_R>"));
   std::vector<double> r(numPoints), dr(numPoints);
-  for (int i = 0; i < numPoints; i++)
+  for (int i=0; i<numPoints; i++)
     assert(parser.ReadDouble(r[i]));
   assert(parser.FindToken("</PP_R>"));
   PotentialGrid.Init(r);
 
 
   assert(parser.FindToken("<PP_RAB>"));
-  for (int i = 0; i < numPoints; i++)
+  for (int i=0; i<numPoints; i++)
     assert(parser.ReadDouble(dr[i]));
   assert(parser.FindToken("</PP_RAB>"));
   assert(parser.FindToken("</PP_MESH>"));
 
   assert(parser.FindToken("<PP_LOCAL>"));
   std::vector<double> Vlocal(numPoints);
-  for (int i = 0; i < numPoints; i++)
-  {
+  for (int i=0; i<numPoints; i++) {
     assert(parser.ReadDouble(Vlocal[i]));
     Vlocal[i] *= 0.5;
   }
@@ -1357,245 +1275,232 @@ bool PseudoClass::ReadUPF_PP(std::string fileName)
 
   // Store which channels have nonlocal projectors:
   // Input:  l    Output:  index of projector
-  std::map<int, int> lmap;
+  std::map<int,int> lmap;
   std::vector<KBprojector> projectors;
-  for (int proj = 0; proj < numProj; proj++)
-  {
-    assert(parser.FindToken("<PP_BETA>"));
+  for (int proj=0; proj<numProj; proj++) {
+    assert (parser.FindToken("<PP_BETA>"));
     int Beta;
-    assert(parser.ReadInt(Beta));
-    assert(Beta == (proj + 1));
+    assert (parser.ReadInt(Beta));
+    assert(Beta == (proj+1));
     int l;
-    assert(parser.ReadInt(l));
-    parser.NextLine();
+    assert (parser.ReadInt(l));    parser.NextLine();
     lmap[l] = proj;
     //    fprintf (stderr, "Found a projector for l=%d\n", l);
 
     int npt;
-    assert(parser.ReadInt(npt));
+    assert (parser.ReadInt(npt));
 
     std::vector<double> beta(numPoints);
-    for (int ir = 0; ir < numPoints; ir++)
+    for (int ir=0; ir<numPoints; ir++)
       assert(parser.ReadDouble(beta[ir]));
-    assert(parser.FindToken("</PP_BETA>"));
+    assert (parser.FindToken("</PP_BETA>"));
 
     projectors.push_back(KBprojector(l, beta));
   }
   assert(parser.FindToken("</PP_NONLOCAL>"));
 
-  int llocal = 0;
-  while (lmap.find(llocal) != lmap.end())
-    llocal++;
+  int llocal=0;
+  while (lmap.find(llocal) != lmap.end()) llocal++;
   LocalChannel = llocal;
   //  fprintf (stderr, "First channel without a projector=%d\n", llocal);
   ChannelPotentials[llocal].Vl.Init(PotentialGrid, Vlocal);
   std::vector<double> Vlocal_r(numPoints);
-  for (int ir = 0; ir < numPoints; ir++)
-    Vlocal_r[ir] = r[ir] * Vlocal[ir];
+  for (int ir=0; ir<numPoints; ir++)
+    Vlocal_r[ir] = r[ir]*Vlocal[ir];
   ChannelPotentials[llocal].Vlr.Init(PotentialGrid, Vlocal_r);
   ChannelPotentials[llocal].l = llocal;
 
-  if (numWF)
-  {
-    assert(parser.FindToken("PP_PSWFC"));
-    assert(parser.NextLine());
-    for (int iwf = 0; iwf < numWF; iwf++)
-    {
+  if (numWF) {
+    assert (parser.FindToken("PP_PSWFC"));
+    assert (parser.NextLine());
+    for (int iwf=0; iwf<numWF; iwf++) {
       std::string NL;
-      assert(parser.ReadWord(NL));
+      assert (parser.ReadWord(NL));
       int l;
-      assert(parser.ReadInt(l));
+      assert (parser.ReadInt(l));
       double occ;
-      assert(parser.ReadDouble(occ));
+      assert (parser.ReadDouble(occ));
       parser.NextLine();
       std::vector<double> wf(numPoints);
-      for (int ir = 0; ir < numPoints; ir++)
-        assert(parser.ReadDouble(wf[ir]));
+      for (int ir=0; ir<numPoints; ir++)
+	assert (parser.ReadDouble(wf[ir]));
       // Now, setup the channel potentials
-      if (l != llocal)
-      {
-        assert(lmap.find(l) != lmap.end());
-        KBprojector& proj = projectors[lmap[l]];
-        std::vector<double> Vl(numPoints), Vlr(numPoints);
-        for (int ir = 0; ir < numPoints; ir++)
-        {
-          Vl[ir] = Vlocal[ir];
-          if (wf[ir] != 0.0)
-            Vl[ir] += proj.beta[ir] / (2.0 * wf[ir]);
-          Vlr[ir] = r[ir] * Vl[ir];
-        }
-        Vl[0]  = 2.0 * Vl[1] - Vl[2];
-        Vlr[0] = r[0] * Vl[0];
+      if (l != llocal) {
+	assert (lmap.find(l) != lmap.end());
+	KBprojector &proj = projectors[lmap[l]];
+	std::vector<double> Vl(numPoints), Vlr(numPoints);
+	for (int ir=0; ir<numPoints; ir++) {
+	  Vl[ir]  = Vlocal[ir];
+	  if (wf[ir] != 0.0)
+	    Vl[ir] += proj.beta[ir]/(2.0*wf[ir]);
+	  Vlr[ir] = r[ir]*Vl[ir];
+	}
+	Vl[0] = 2.0*Vl[1] - Vl[2];
+	Vlr[0] = r[0] * Vl[0];
 
-        // 	for (int ir=0; ir<numPoints; ir++)
-        // 	  fprintf (stderr, "Vl(%8.3f) = %22.16f\n", r[ir], Vl[ir]);
+// 	for (int ir=0; ir<numPoints; ir++)
+// 	  fprintf (stderr, "Vl(%8.3f) = %22.16f\n", r[ir], Vl[ir]);
 
-        ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
-        ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
-        ChannelPotentials[l].l = l;
+	ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
+	ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
+	ChannelPotentials[l].l = l;
       }
       ChannelPotentials[l].ul.Init(PotentialGrid, wf);
-      ChannelPotentials[l].Occupation   = occ;
+      ChannelPotentials[l].Occupation = occ;
       ChannelPotentials[l].HasProjector = true;
     }
 
-    assert(parser.FindToken("/PP_PSWFC"));
+    assert (parser.FindToken("/PP_PSWFC"));
   }
 
   // Now, figure out what rcut should be
   double rmax = PotentialGrid.End();
-  int n       = PotentialGrid.NumPoints() - 1;
-  bool diff   = false;
-  while ((n > 0) && !diff)
-  {
+  int n = PotentialGrid.NumPoints()-1;
+  bool diff = false;
+  while ((n>0) && !diff) {
     double r = PotentialGrid[n];
-    rmax     = r;
-    for (int l1 = 0; l1 < numChannels; l1++)
-    {
+    rmax = r;
+    for (int l1=0; l1<numChannels; l1++) {
       double Vl1 = ChannelPotentials[l1].Vl(r);
-      for (int l2 = l1 + 1; l2 < numChannels; l2++)
-      {
-        double Vl2 = ChannelPotentials[l2].Vl(r);
-        if (fabs(Vl1 - Vl2) > 1.0e-5)
-          diff = true;
+      for (int l2=l1+1; l2<numChannels; l2++) {
+	double Vl2 = ChannelPotentials[l2].Vl(r);
+	if (fabs(Vl1-Vl2) > 1.0e-5)
+	  diff = true;
       }
     }
     n--;
   }
-  fprintf(stderr, "rmax = %1.5f  numChannels = %d\n", rmax, numChannels);
-  for (int l = 0; l < ChannelPotentials.size(); l++)
+  fprintf (stderr, "rmax = %1.5f  numChannels = %d\n", rmax, numChannels);
+  for (int l=0; l<ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rmax;
 
   parser.CloseFile();
 
   // Read top comment line
-  //   assert (parser.ReadLine(temp));
-  //   double atomCharge;
-  //   assert (parser.ReadDouble(atomCharge));
-  //   AtomicNumber = (int)round(atomCharge);
-  //   assert (parser.ReadDouble(PseudoCharge));
-  //   int date, pspcode, pspxc, lmax, lloc, mmax;
-  //   assert (parser.ReadInt(date));
-  //   assert (parser.ReadLine(temp));
-  //   assert (parser.ReadInt(pspcode));
-  //   assert (parser.ReadInt(pspxc));
-  //   assert (parser.ReadInt(lmax));
-  //   assert (parser.ReadInt(LocalChannel));
-  //   assert (parser.ReadInt(mmax));
-  //   // Read the rest of the line and skip the next 4
-  //   for (int i=0; i<5; i++)
-  //     assert (parser.FindToken("\n"));
-  //   // Now we are in the FHI file proper
-  //   double chrg;
-  //   assert (parser.ReadDouble(chrg));
-  //   if(fabs(chrg-PseudoCharge) > 1.0e-10) {
-  //     cerr << "PseudoCharge = " << PseudoCharge << endl;
-  //     cerr << "chrg = " << chrg << endl;
-  //   }
+//   assert (parser.ReadLine(temp));
+//   double atomCharge;
+//   assert (parser.ReadDouble(atomCharge));
+//   AtomicNumber = (int)round(atomCharge);
+//   assert (parser.ReadDouble(PseudoCharge));
+//   int date, pspcode, pspxc, lmax, lloc, mmax;
+//   assert (parser.ReadInt(date));
+//   assert (parser.ReadLine(temp));
+//   assert (parser.ReadInt(pspcode));
+//   assert (parser.ReadInt(pspxc));
+//   assert (parser.ReadInt(lmax));
+//   assert (parser.ReadInt(LocalChannel));
+//   assert (parser.ReadInt(mmax));
+//   // Read the rest of the line and skip the next 4
+//   for (int i=0; i<5; i++)
+//     assert (parser.FindToken("\n"));
+//   // Now we are in the FHI file proper
+//   double chrg;
+//   assert (parser.ReadDouble(chrg));
+//   if(fabs(chrg-PseudoCharge) > 1.0e-10) {
+//     cerr << "PseudoCharge = " << PseudoCharge << endl;
+//     cerr << "chrg = " << chrg << endl;
+//   }
 
-  //   // Read number of channels and resize
-  //   int numChannels;
-  //   assert (parser.ReadInt(numChannels));
-  //   ChannelPotentials.resize(numChannels);
+//   // Read number of channels and resize
+//   int numChannels;
+//   assert (parser.ReadInt(numChannels));
+//   ChannelPotentials.resize(numChannels);
 
-  //   // Skip the next 10 lines
-  //   for (int i=0; i<11; i++)
-  //     assert (parser.FindToken("\n"));
+//   // Skip the next 10 lines
+//   for (int i=0; i<11; i++)
+//     assert (parser.FindToken("\n"));
 
-  //   // Read the number of grid points
-  //   for (int l=0; l<numChannels; l++) {
-  //     int numPoints;
-  //     double a_ratio;
-  //     assert (parser.ReadInt(numPoints));
-  //     assert (parser.ReadDouble(a_ratio));
-  //     vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
-  //       Vlr(numPoints);
-  //     for (int m=0; m<numPoints; m++) {
-  //       int mtest;
-  //       assert (parser.ReadInt(mtest));
-  //       assert (mtest == (m+1));
-  //       assert (parser.ReadDouble(points[m]));
-  //       assert (parser.ReadDouble(ul[m]));
-  //       assert (parser.ReadDouble(Vl[m]));
-  //       Vlr[m] = Vl[m]*points[m];
-  //     }
-  //     PotentialGrid.Init (points);
-  //     ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
-  //     ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
-  //     ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
-  //     ChannelPotentials[l].l = l;
-  //     ChannelPotentials[l].n_principal = -1;
-  //     ChannelPotentials[l].Cutoff = 0.0;
-  //     ChannelPotentials[l].HasProjector = true;
-  //   }
-  //   // Now, figure out what rcut should be
-  //   double rmax = PotentialGrid.End();
-  //   int n = PotentialGrid.NumPoints()-1;
-  //   bool diff = false;
-  //   while ((n>0) && !diff) {
-  //     double r = PotentialGrid[n];
-  //     rmax = r;
-  //     for (int l1=0; l1<numChannels; l1++) {
-  //       double Vl1 = ChannelPotentials[l1].Vl(r);
-  //       for (int l2=l1+1; l2<numChannels; l2++) {
-  // 	double Vl2 = ChannelPotentials[l2].Vl(r);
-  // 	if (fabs(Vl1-Vl2) > 1.0e-5)
-  // 	  diff = true;
-  //       }
-  //     }
-  //     n--;
-  //   }
-  //   for (int l=0; l<ChannelPotentials.size(); l++)
-  //     ChannelPotentials[l].Cutoff = rmax;
+//   // Read the number of grid points
+//   for (int l=0; l<numChannels; l++) {
+//     int numPoints;
+//     double a_ratio;
+//     assert (parser.ReadInt(numPoints));
+//     assert (parser.ReadDouble(a_ratio));
+//     vector<double> points(numPoints), ul(numPoints), Vl(numPoints),
+//       Vlr(numPoints);
+//     for (int m=0; m<numPoints; m++) {
+//       int mtest;
+//       assert (parser.ReadInt(mtest));
+//       assert (mtest == (m+1));
+//       assert (parser.ReadDouble(points[m]));
+//       assert (parser.ReadDouble(ul[m]));
+//       assert (parser.ReadDouble(Vl[m]));
+//       Vlr[m] = Vl[m]*points[m];
+//     }
+//     PotentialGrid.Init (points);
+//     ChannelPotentials[l].Vl.Init  (PotentialGrid, Vl);
+//     ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlr);
+//     ChannelPotentials[l].ul.Init  (PotentialGrid, ul);
+//     ChannelPotentials[l].l = l;
+//     ChannelPotentials[l].n_principal = -1;
+//     ChannelPotentials[l].Cutoff = 0.0;
+//     ChannelPotentials[l].HasProjector = true;
+//   }
+//   // Now, figure out what rcut should be
+//   double rmax = PotentialGrid.End();
+//   int n = PotentialGrid.NumPoints()-1;
+//   bool diff = false;
+//   while ((n>0) && !diff) {
+//     double r = PotentialGrid[n];
+//     rmax = r;
+//     for (int l1=0; l1<numChannels; l1++) {
+//       double Vl1 = ChannelPotentials[l1].Vl(r);
+//       for (int l2=l1+1; l2<numChannels; l2++) {
+// 	double Vl2 = ChannelPotentials[l2].Vl(r);
+// 	if (fabs(Vl1-Vl2) > 1.0e-5)
+// 	  diff = true;
+//       }
+//     }
+//     n--;
+//   }
+//   for (int l=0; l<ChannelPotentials.size(); l++)
+//     ChannelPotentials[l].Cutoff = rmax;
 
-  //   parser.CloseFile();
-  return true;
+//   parser.CloseFile();
+   return true;
 }
 
-bool PseudoClass::ReadGAMESS_PP(std::string fileName)
+bool
+PseudoClass::ReadGAMESS_PP (std::string fileName)
 {
   MemParserClass parser;
-  assert(parser.OpenFile(fileName));
+  assert (parser.OpenFile (fileName));
 
   std::string psp_name, psp_type;
-  assert(parser.ReadWord(psp_name));
-  assert(parser.ReadWord(psp_type));
+  assert (parser.ReadWord(psp_name));
+  assert (parser.ReadWord(psp_type));
   // izcore is the number of core electrons removed
   // Find atomic number.
   std::string symbol;
-  int i = 0;
-  while ((i < psp_name.size()) && (psp_name[i] != '-'))
-  {
+  int i=0;
+  while ((i<psp_name.size()) && (psp_name[i] != '-')) {
     symbol = symbol + psp_name[i];
     i++;
   }
   std::cerr << "Atomic symbol = " << symbol << std::endl;
-  int Z        = SymbolToZMap[symbol];
+  int Z = SymbolToZMap[symbol];
   AtomicNumber = Z;
   int izcore, lmax;
-  assert(parser.ReadInt(izcore));
-  PseudoCharge = (double)(Z - izcore);
-  assert(parser.ReadInt(lmax));
-  assert(parser.FindToken("\n"));
-  if (LocalChannel < 0)
-    LocalChannel = lmax;
+  assert (parser.ReadInt(izcore));
+  PseudoCharge = (double)(Z-izcore);
+  assert (parser.ReadInt(lmax));
+  assert (parser.FindToken("\n"));
+  if (LocalChannel<0) LocalChannel = lmax;
 
-  ChannelPotentials.resize(lmax + 1);
+  ChannelPotentials.resize(lmax+1);
 
   // Setup the potential grid
   std::vector<double> rPoints;
-  if (WriteLogGrid)
-  {
+  if (WriteLogGrid) {
     const int numPoints = 2001;
-    double end          = 150.0;
-    double step         = 0.00625;
-    double scale        = end / (expm1(step * (numPoints - 1)));
-    for (int i = 1; i < numPoints; i++)
-      rPoints.push_back(scale * (expm1(step * i)));
+    double end = 150.0;
+    double step  = 0.00625;
+    double scale = end/(expm1(step*(numPoints-1)));
+    for (int i=1; i<numPoints; i++)
+      rPoints.push_back(scale * (expm1(step*i)));
   }
-  else
-  {
-    for (double r = 1.0e-10; r <= 150.00001; r += 0.005)
+  else {
+    for (double r=1.0e-10; r<=150.00001; r+=0.005)
       rPoints.push_back(r);
   }
   PotentialGrid.Init(rPoints);
@@ -1605,82 +1510,74 @@ bool PseudoClass::ReadGAMESS_PP(std::string fileName)
   std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
   std::cerr << "lmax = " << lmax << std::endl;
 
-  for (int index = 0; index <= lmax; index++)
-  {
+  for (int index=0; index<=lmax; index++) {
     // lmax is first, followed by 0, 1, etc.
-    int l = (index + lmax) % (lmax + 1);
+    int l = (index+lmax)%(lmax+1);
     int ngpot;
-    assert(parser.ReadInt(ngpot));
-    assert(parser.FindToken("\n"));
+    assert (parser.ReadInt (ngpot));
+    assert (parser.FindToken("\n"));
     std::vector<double> coefs(ngpot), exponents(ngpot);
     std::vector<int> powers(ngpot);
 
     // The local channel is given first
-    for (int i = 0; i < ngpot; i++)
-    {
-      assert(parser.ReadDouble(coefs[i]));
-      assert(parser.ReadInt(powers[i]));
-      assert(parser.ReadDouble(exponents[i]));
-      assert(parser.FindToken("\n"));
+    for (int i=0; i<ngpot; i++) {
+      assert (parser.ReadDouble(    coefs[i]));
+      assert (parser.ReadInt(      powers[i]));
+      assert (parser.ReadDouble(exponents[i]));
+      assert (parser.FindToken ("\n"));
     }
     // Now, setup potentials
-    if (index == 0)
-    {
-      for (int n = 0; n < N; n++)
-      {
-        double r   = rPoints[n];
-        double val = 0.0;
-        for (int i = 0; i < ngpot; i++)
-          val += coefs[i] * pow(r, (double)(powers[i] - 2)) * exp(-exponents[i] * r * r);
-        Vlocal[n]   = val - (double)PseudoCharge / r;
-        Vlocal_r[n] = r * val - (double)PseudoCharge;
+    if (index == 0) {
+      for (int n=0; n<N; n++) {
+	double r = rPoints[n];
+	double val = 0.0;
+	for (int i=0; i<ngpot; i++)
+	  val += coefs[i] * pow(r,(double)(powers[i]-2))
+	    * exp(-exponents[i]*r*r);
+	Vlocal[n]   =   val -(double)PseudoCharge/r;
+	Vlocal_r[n] = r*val - (double)PseudoCharge;
       }
       ChannelPotentials[l].l = l;
-      ChannelPotentials[l].Vl.Init(PotentialGrid, Vlocal);
-      ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlocal_r);
+      ChannelPotentials[l].Vl.Init (PotentialGrid, Vlocal);
+      ChannelPotentials[l].Vlr.Init (PotentialGrid, Vlocal_r);
     }
-    else
-    {
-      for (int n = 0; n < N; n++)
-      {
-        double r   = rPoints[n];
-        double val = 0.0;
-        for (int i = 0; i < ngpot; i++)
-          val += coefs[i] * pow(r, (double)(powers[i] - 2)) * exp(-exponents[i] * r * r);
-        Vl[n]   = Vlocal[n] + val;
-        Vl_r[n] = Vlocal_r[n] + r * val;
+    else {
+      for (int n=0; n<N; n++) {
+	double r = rPoints[n];
+	double val = 0.0;
+	for (int i=0; i<ngpot; i++)
+	  val += coefs[i] * pow(r,(double)(powers[i]-2))
+	    * exp(-exponents[i]*r*r);
+	Vl[n]   = Vlocal[n] + val;
+	Vl_r[n] = Vlocal_r[n] + r*val;
       }
       ChannelPotentials[l].l = l;
-      ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
-      ChannelPotentials[l].Vlr.Init(PotentialGrid, Vl_r);
+      ChannelPotentials[l].Vl.Init (PotentialGrid, Vl);
+      ChannelPotentials[l].Vlr.Init (PotentialGrid, Vl_r);
     }
   }
   // Now, compute cutoff radius
-  bool done = false;
-  int ir    = rPoints.size() - 1;
-  if (ChannelPotentials.size() > 1)
-  {
-    while (ir > 0 && !done)
-    {
+  bool done=false;
+  int ir = rPoints.size()-1;
+  if (ChannelPotentials.size() > 1) {
+    while (ir > 0 && !done) {
       double vlocal = ChannelPotentials[LocalChannel].Vl(ir);
-      for (int l = 0; l < ChannelPotentials.size(); l++)
-        if (ChannelPotentials[l].l != LocalChannel)
-          if (fabs(ChannelPotentials[l].Vl(ir) - vlocal) > 1.0e-5)
-            done = true;
+      for (int l=0; l<ChannelPotentials.size(); l++)
+	if (ChannelPotentials[l].l != LocalChannel)
+	  if (fabs(ChannelPotentials[l].Vl(ir) - vlocal) > 1.0e-5)
+	    done = true;
       ir--;
     }
   }
-  else
-  {
-    while (ir > 0 && !done)
-    {
+  else {
+    while (ir > 0 && !done) {
       double vlocal = ChannelPotentials[LocalChannel].Vl(ir);
-      double r      = rPoints[ir];
-      done          = fabs(vlocal + PseudoCharge / r) > 1.0e-5;
+      double r = rPoints[ir];
+      done = fabs (vlocal + PseudoCharge/r) > 1.0e-5;
       ir--;
     }
   }
-  for (int l = 0; l < ChannelPotentials.size(); l++)
+  for (int l=0; l<ChannelPotentials.size(); l++)
     ChannelPotentials[l].Cutoff = rPoints[ir];
 
 
@@ -1688,24 +1585,26 @@ bool PseudoClass::ReadGAMESS_PP(std::string fileName)
   return true;
 }
 
-bool ReadInt(std::string& s, int& n)
+bool
+ReadInt (std::string &s, int &n)
 {
-  int pos = 0;
+  int pos=0;
   std::string sint;
   while (s[pos] >= '0' && s[pos] <= '9')
     sint.push_back(s[pos++]);
-  s.erase(0, pos);
-  n = atoi(sint.c_str());
+  s.erase(0,pos);
+  n = atoi (sint.c_str());
   return true;
 }
 
-bool ReadDouble(std::string& s, double& x)
+bool
+ReadDouble (std::string &s, double &x)
 {
-  int pos = 0;
+  int pos=0;
   std::string sd;
-  while ((s[pos] >= '0' && s[pos] <= '9') || s[pos] == '.')
+  while ((s[pos] >= '0' && s[pos] <= '9') || s[pos]=='.')
     sd.push_back(s[pos++]);
-  s.erase(0, pos);
+  s.erase(0,pos);
   x = strtod(sd.c_str(), (char**)NULL);
   return true;
 }
@@ -1718,169 +1617,161 @@ Config::Config(std::string s)
   ChannelRevMap['d'] = 2;
   ChannelRevMap['f'] = 3;
   ChannelRevMap['g'] = 4;
-  while (s.size() > 0)
-  {
+  while (s.size() > 0) {
     int n, l;
     double occ;
-    ReadInt(s, n);
+    ReadInt (s, n);
     l = ChannelRevMap[s[0]];
-    s.erase(0, 1);
-    assert(s[0] == '(');
-    s.erase(0, 1);
-    ReadDouble(s, occ);
-    assert(s[0] == ')');
-    s.erase(0, 1);
-    States.push_back(State(n, l, occ));
+    s.erase(0,1);
+    assert (s[0] == '(');
+    s.erase(0,1);
+    ReadDouble (s, occ);
+    assert (s[0] == ')');
+    s.erase(0,1);
+    States.push_back (State(n,l,occ));
   }
 }
 
 
-bool PseudoClass::ReadCASINO_PP(std::string fileName)
+
+bool
+PseudoClass::ReadCASINO_PP (std::string fileName)
 {
   MemParserClass parser;
-  parser.OpenFile(fileName);
+  parser.OpenFile (fileName);
 
-  assert(parser.FindToken("pseudo-charge"));
-  assert(parser.ReadInt(AtomicNumber));
-  assert(parser.ReadDouble(PseudoCharge));
-  assert(parser.FindToken("(rydberg/hartree/ev)"));
-  assert(parser.FindToken("\n"));
-  assert(parser.ReadWord(EnergyUnit));
+  assert (parser.FindToken("pseudo-charge"));
+  assert (parser.ReadInt (AtomicNumber));
+  assert (parser.ReadDouble (PseudoCharge));
+  assert (parser.FindToken("(rydberg/hartree/ev)"));
+  assert (parser.FindToken("\n"));
+  assert (parser.ReadWord(EnergyUnit));
   std::cerr << "EnergyUnit = " << EnergyUnit << std::endl;
-  assert(parser.FindToken("(0=s,1=p,2=d..)"));
-  assert(parser.ReadInt(LocalChannel));
-  assert(parser.FindToken("grid points"));
+  assert (parser.FindToken("(0=s,1=p,2=d..)"));
+  assert (parser.ReadInt (LocalChannel));
+  assert (parser.FindToken("grid points"));
   int numGridPoints;
-  assert(parser.ReadInt(numGridPoints));
-  std::vector<double> gridPoints(numGridPoints), Vl(numGridPoints), Vlr(numGridPoints);
-  assert(parser.FindToken("in"));
-  assert(parser.ReadWord(LengthUnit));
+  assert (parser.ReadInt(numGridPoints));
+  std::vector<double> gridPoints(numGridPoints), Vl(numGridPoints),
+    Vlr(numGridPoints);
+  assert (parser.FindToken ("in"));
+  assert (parser.ReadWord(LengthUnit));
   std::cerr << "LengthUnit = " << LengthUnit << std::endl;
-  assert(parser.FindToken("\n"));
+  assert (parser.FindToken("\n"));
   //  assert (parser.FindToken("atomic units"));
-  for (int i = 0; i < numGridPoints; i++)
-  {
-    assert(parser.ReadDouble(gridPoints[i]));
-    gridPoints[i] *= UnitToBohrMap[LengthUnit];
+  for (int i=0; i<numGridPoints; i++) {
+    assert (parser.ReadDouble(gridPoints[i]));
+    gridPoints[i] *= UnitToBohrMap [LengthUnit];
   }
-  PotentialGrid.Init(gridPoints);
-  int l           = 0;
-  int numChannels = 0;
+  PotentialGrid.Init (gridPoints);
+  int l=0;
+  int numChannels=0;
   bool done(false);
-  while (!done)
-  {
+  while (!done) {
     if (!parser.FindToken("(L="))
       done = true;
-    else
-    {
+    else {
       numChannels++;
-      assert(parser.ReadInt(l));
-      assert(parser.FindToken("\n"));
-      for (int i = 0; i < numGridPoints; i++)
-      {
-        assert(parser.ReadDouble(Vl[i]));
-        Vl[i] *= UnitToHartreeMap[EnergyUnit];
-        Vlr[i] = Vl[i];
-        Vl[i] /= PotentialGrid[i];
+      assert (parser.ReadInt(l));
+      assert (parser.FindToken("\n"));
+      for (int i=0; i<numGridPoints; i++) {
+      	assert (parser.ReadDouble(Vl[i]));
+      	Vl[i] *= UnitToHartreeMap[EnergyUnit];
+      	Vlr[i] = Vl[i];
+      	Vl[i] /= PotentialGrid[i];
       }
-      Vl[0] = 2.0 * Vl[1] - Vl[2];
+      Vl[0] = 2.0*Vl[1]-Vl[2];
       ChannelPotentials.push_back(ChannelPotentialClass());
       ChannelPotentials[l].Vl.Init(PotentialGrid, Vl);
       ChannelPotentials[l].Vlr.Init(PotentialGrid, Vlr);
       ChannelPotentials[l].l = l;
     }
   }
-  //  std::cerr << "Found " << (l+1) << " l-channel potentials.\n";
+//  std::cerr << "Found " << (l+1) << " l-channel potentials.\n";
   std::cerr << "Found " << numChannels << " l-channel potentials.\n";
 
   // Now read the summary file to get core radii
-  if (parser.OpenFile("summary.txt"))
-  {
+  if (parser.OpenFile ("summary.txt")) {
     std::string summaryUnits;
-    assert(parser.FindToken("Units:"));
-    assert(parser.ReadWord(summaryUnits));
-    assert(parser.FindToken("core radii"));
-    assert(parser.FindToken("\n"));
-    assert(parser.FindToken("\n"));
+    assert (parser.FindToken("Units:"));
+    assert (parser.ReadWord (summaryUnits));
+    assert (parser.FindToken("core radii"));
+    assert (parser.FindToken("\n"));
+    assert (parser.FindToken("\n"));
     // Read core radii
     double rc;
-    for (int i = 0; i <= l; i++)
-    {
-      assert(parser.FindToken(ChannelMap[i]));
-      assert(parser.ReadDouble(rc));
+    for (int i=0; i<=l; i++) {
+      assert (parser.FindToken (ChannelMap[i]));
+      assert (parser.ReadDouble (rc));
       ChannelPotentials[i].Cutoff = rc;
     }
 
-    assert(parser.FindToken("r_loc"));
-    assert(parser.FindToken("\n"));
-    assert(parser.FindToken("\n"));
-    assert(parser.FindToken("(Grid)"));
+    assert (parser.FindToken("r_loc"));
+    assert (parser.FindToken("\n"));
+    assert (parser.FindToken("\n"));
+    assert (parser.FindToken("(Grid)"));
     double rloc;
-    assert(parser.ReadDouble(rloc));
+    assert (parser.ReadDouble(rloc));
 
     // Overwrite radius with localization radius
-    for (int i = 0; i <= l; i++)
+    for (int i=0; i<=l; i++)
       ChannelPotentials[i].Cutoff = rloc;
 
     // Find ground state occupations
-    assert(parser.FindToken("Eigenvalues of the"));
+    assert (parser.FindToken ("Eigenvalues of the"));
     std::string GSconfig;
-    parser.ReadWord(GSconfig);
+    parser.ReadWord (GSconfig);
     Config c(GSconfig);
-    for (int is = 0; is < c.size(); is++)
+    for (int is=0; is<c.size(); is++)
       ChannelPotentials[c[is].l].Occupation = c[is].occ;
 
     // Now read eigenvalues of ground state
-    assert(parser.FindToken("Pseudo HF"));
-    assert(parser.FindToken("\n"));
-    assert(parser.FindToken("\n"));
+    assert (parser.FindToken ("Pseudo HF"));
+    assert (parser.FindToken ("\n"));
+    assert (parser.FindToken ("\n"));
     std::string channel;
-    parser.ReadWord(channel);
-    while ((channel == "s") || (channel == "p") || (channel == "d") || (channel == "f") || (channel == "g"))
-    {
+    parser.ReadWord (channel);
+    while ((channel=="s") || (channel=="p") || (channel=="d") ||
+  	 (channel=="f") || (channel=="g")) {
       int l = ChannelRevMap[channel];
       std::string tmp;
-      parser.ReadWord(tmp);
-      assert(parser.ReadDouble(ChannelPotentials[l].Eigenvalue));
+      parser.ReadWord (tmp);
+      assert (parser.ReadDouble (ChannelPotentials[l].Eigenvalue));
       ChannelPotentials[l].Eigenvalue *= UnitToHartreeMap[summaryUnits];
-      std::cerr << "Eigenvalue for " << channel << "-channel = " << ChannelPotentials[l].Eigenvalue << std::endl;
-      parser.ReadLine(tmp);
-      parser.ReadWord(channel);
+      std::cerr << "Eigenvalue for " << channel << "-channel = "
+  	 << ChannelPotentials[l].Eigenvalue << std::endl;
+      parser.ReadLine (tmp);
+      parser.ReadWord (channel);
     }
     // Read total energy
-    assert(parser.FindToken("total energy"));
-    assert(parser.FindToken("="));
-    assert(parser.ReadDouble(TotalEnergy));
+    assert (parser.FindToken ("total energy"));
+    assert (parser.FindToken ("="));
+    assert (parser.ReadDouble (TotalEnergy));
     TotalEnergy *= UnitToHartreeMap[summaryUnits];
     std::cerr << "Total energy = " << TotalEnergy << std::endl;
-  }
-  else
-  {
+  } else {
     // Now, figure out what rcut should be
     double rmax = PotentialGrid.End();
-    int n       = PotentialGrid.NumPoints() - 1;
-    bool diff   = false;
-    while ((n > 0) && !diff)
-    {
+    int n = PotentialGrid.NumPoints()-1;
+    bool diff = false;
+    while ((n>0) && !diff) {
       double r = PotentialGrid[n];
-      rmax     = r;
-      for (int l1 = 0; l1 < numChannels; l1++)
-      {
+      rmax = r;
+      for (int l1=0; l1<numChannels; l1++) {
         double Vl1 = ChannelPotentials[l1].Vl(r);
-        for (int l2 = l1 + 1; l2 < numChannels; l2++)
-        {
-          double Vl2 = ChannelPotentials[l2].Vl(r);
-          if (fabs(Vl1 - Vl2) > 1.0e-6)
-            diff = true;
+        for (int l2=l1+1; l2<numChannels; l2++) {
+    double Vl2 = ChannelPotentials[l2].Vl(r);
+    if (fabs(Vl1-Vl2) > 1.0e-6)
+      diff = true;
         }
       }
       n--;
     }
-    for (int l = 0; l < ChannelPotentials.size(); l++)
+    for (int l=0; l<ChannelPotentials.size(); l++)
       ChannelPotentials[l].Cutoff = rmax;
   }
-  //   for (int i=0; i<=l; i++)
-  //     ChannelPotentials[i].Cutoff = rloc;
+//   for (int i=0; i<=l; i++)
+//     ChannelPotentials[i].Cutoff = rloc;
 
   return true;
 }
@@ -1888,104 +1779,104 @@ bool PseudoClass::ReadCASINO_PP(std::string fileName)
 
 /// Note:  the pseudopotentials must be read before the wave
 /// functions.
-bool PseudoClass::ReadCASINO_WF(std::string fileName, int l)
+bool
+PseudoClass::ReadCASINO_WF (std::string fileName, int l)
 {
   // Make sure that l is not too high
-  assert(l < ChannelPotentials.size());
+  assert (l < ChannelPotentials.size());
   MemParserClass parser;
-  parser.OpenFile(fileName);
+  parser.OpenFile (fileName);
 
   // Make sure this a wave function file
-  assert(parser.FindToken("wave function"));
+  assert (parser.FindToken ("wave function"));
   // Find atomic number
-  assert(parser.FindToken("Atomic number"));
+  assert (parser.FindToken ("Atomic number"));
   int atomicNumber;
-  assert(parser.ReadInt(atomicNumber));
-  assert(atomicNumber == AtomicNumber);
+  assert (parser.ReadInt(atomicNumber));
+  assert (atomicNumber == AtomicNumber);
   int numOrbitals;
-  assert(parser.FindToken("number of orbitals"));
-  assert(parser.ReadInt(numOrbitals));
-  assert(parser.FindToken("Radial grid"));
-  assert(parser.FindToken("\n"));
+  assert (parser.FindToken("number of orbitals"));
+  assert (parser.ReadInt(numOrbitals));
+  assert (parser.FindToken("Radial grid"));
+  assert (parser.FindToken("\n"));
   int numPoints;
-  assert(parser.ReadInt(numPoints));
-  assert(PotentialGrid.NumPoints() == numPoints);
+  assert (parser.ReadInt(numPoints));
+  assert (PotentialGrid.NumPoints() == numPoints);
   // Make sure we have the same grid as the potential file
-  for (int i = 0; i < numPoints; i++)
-  {
+  for (int i=0; i<numPoints; i++) {
     double r;
     assert(parser.ReadDouble(r));
-    assert(fabs(r - PotentialGrid[i]) < 1.0e-10);
+    assert (fabs(r-PotentialGrid[i]) < 1.0e-10);
   }
   bool orbFound = false;
-  for (int i = 0; i < numOrbitals; i++)
-  {
-    assert(parser.FindToken("Orbital #"));
-    assert(parser.FindToken("\n"));
+  for (int i=0; i<numOrbitals; i++) {
+    assert (parser.FindToken ("Orbital #"));
+    assert (parser.FindToken ("\n"));
     int spin, n, thisl;
-    assert(parser.ReadInt(spin));
-    assert(parser.ReadInt(n));
-    assert(parser.ReadInt(thisl));
-    if (thisl == l)
-    {
+    assert (parser.ReadInt(spin));
+    assert (parser.ReadInt(n));
+    assert (parser.ReadInt(thisl));
+    if (thisl == l) {
       std::vector<double> ul(numPoints);
-      for (int i = 0; i < numPoints; i++)
-        assert(parser.ReadDouble(ul[i]));
+      for (int i=0; i<numPoints; i++)
+	assert (parser.ReadDouble(ul[i]));
       ChannelPotentials[l].ul.Init(PotentialGrid, ul);
       ChannelPotentials[l].HasProjector = true;
-      ChannelPotentials[l].n_principal  = n;
-      orbFound                          = true;
+      ChannelPotentials[l].n_principal = n;
+      orbFound = true;
     }
   }
-  if (!orbFound)
-  {
+  if (!orbFound) {
     std::cerr << "Could not file orbital with l=" << l
-              << " in file "
-                 "filename"
-                 ""
-              << std::endl;
+	 << " in file ""filename""" << std::endl;
     exit(1);
   }
   return true;
 }
 
-int PseudoClass::GetNumChannels() { return ChannelPotentials.size(); }
+int
+PseudoClass::GetNumChannels()
+{
+  return ChannelPotentials.size();
+}
 
-bool PseudoClass::HaveProjectors()
+bool
+PseudoClass::HaveProjectors()
 {
   bool has = true;
-  for (int i = 0; i < ChannelPotentials.size(); i++)
+  for (int i=0; i<ChannelPotentials.size(); i++)
     has = has && ChannelPotentials[i].HasProjector;
   return has;
 }
 
 
-int main(int argc, char** argv)
+
+int main(int argc, char **argv)
 {
   // Create list of acceptable command-line parameters
   std::list<ParamClass> argList;
   // input formats
-  argList.push_back(ParamClass("fhi_pot", true));
+  argList.push_back(ParamClass("fhi_pot",   true));
   argList.push_back(ParamClass("casino_pot", true));
-  argList.push_back(ParamClass("bfd_pot", true));
+  argList.push_back(ParamClass("bfd_pot",    true));
   argList.push_back(ParamClass("gamess_pot", true));
   argList.push_back(ParamClass("upf_pot", true));
 
   // Projector parameters
-  argList.push_back(ParamClass("casino_us", true));
-  argList.push_back(ParamClass("casino_up", true));
-  argList.push_back(ParamClass("casino_ud", true));
-  argList.push_back(ParamClass("casino_uf", true));
-  argList.push_back(ParamClass("s_ref", true));
-  argList.push_back(ParamClass("p_ref", true));
-  argList.push_back(ParamClass("d_ref", true));
-  argList.push_back(ParamClass("f_ref", true));
-  argList.push_back(ParamClass("g_ref", true));
-  argList.push_back(ParamClass("xml", true));
-  argList.push_back(ParamClass("tm", true));
-  argList.push_back(ParamClass("upf", true));
-  argList.push_back(ParamClass("fhi", true));
-  argList.push_back(ParamClass("fpmd", true));
+  argList.push_back(ParamClass("casino_us",  true));
+  argList.push_back(ParamClass("casino_up",  true));
+  argList.push_back(ParamClass("casino_ud",  true));
+  argList.push_back(ParamClass("casino_uf",  true));
+  argList.push_back(ParamClass("s_ref",  true));
+  argList.push_back(ParamClass("p_ref",  true));
+  argList.push_back(ParamClass("d_ref",  true));
+  argList.push_back(ParamClass("f_ref",  true));
+  argList.push_back(ParamClass("g_ref",  true));
+  argList.push_back(ParamClass("xml",    true));
+  argList.push_back(ParamClass("tm",     true));
+  argList.push_back(ParamClass("upf",    true));
+  argList.push_back(ParamClass("fhi",    true));
+  argList.push_back(ParamClass("fpmd",   true));
   argList.push_back(ParamClass("casino", true));
   argList.push_back(ParamClass("log_grid", false));
   argList.push_back(ParamClass("local_channel", true));
@@ -1993,38 +1884,37 @@ int main(int argc, char** argv)
 
   CommandLineParserClass parser(argList);
   bool success = parser.Parse(argc, argv);
-  if (!success || parser.NumFiles() != 0)
-  {
+  if (!success || parser.NumFiles()!=0) {
     std::cerr << "Usage:  ppconvert  options\n"
-              << "  Options include:    \n"
-              << "     Input formats:   \n"
-              << "   --casino_pot fname \n"
-              << "   --fhi_pot    fname \n"
-              << "   --upf_pot    fname \n"
-              << "   --bfd_pot    fname \n"
-              << "   --gamess_pot fname \n"
-              << "     Output formats:  \n"
-              << "   --xml  fname.xml   \n"
-              << "   --tm   fname.tm    \n"
-              << "   --upf  fname.upf   \n"
-              << "   --fhi  fname.fhi   \n"
-              << "   --fpmd  fname.xml  \n"
-              << "   --casino fname.xml \n"
-              << "     Reference states:\n"
-              << "   --casino_us fname  \n"
-              << "   --casino_up fname  \n"
-              << "   --casino_ud fname  \n"
-              << "   --casino_uf fname  \n"
-              << "   --casino_ug fname  \n"
-              << "   --s_ref state      \n"
-              << "   --p_ref state      \n"
-              << "   --d_ref state      \n"
-              << "   --f_ref state      \n"
-              << "   --g_ref state      \n"
-              << "     Other options:   \n"
-              << "   --log_grid         \n"
-              << "   --local_channel l (l=0(s),1(p),2(d),3(f),..., default largest possible) \n"
-              << "   --density_mix beta (0 <= beta < 1.0, default 0.75) \n";
+         << "  Options include:    \n"
+         << "     Input formats:   \n"
+         << "   --casino_pot fname \n"
+         << "   --fhi_pot    fname \n"
+         << "   --upf_pot    fname \n"
+         << "   --bfd_pot    fname \n"
+         << "   --gamess_pot fname \n"
+         << "     Output formats:  \n"
+         << "   --xml  fname.xml   \n"
+         << "   --tm   fname.tm    \n"
+         << "   --upf  fname.upf   \n"
+         << "   --fhi  fname.fhi   \n"
+         << "   --fpmd  fname.xml  \n"
+         << "   --casino fname.xml \n"
+         << "     Reference states:\n"
+         << "   --casino_us fname  \n"
+         << "   --casino_up fname  \n"
+         << "   --casino_ud fname  \n"
+         << "   --casino_uf fname  \n"
+         << "   --casino_ug fname  \n"
+         << "   --s_ref state      \n"
+         << "   --p_ref state      \n"
+         << "   --d_ref state      \n"
+         << "   --f_ref state      \n"
+         << "   --g_ref state      \n"
+         << "     Other options:   \n"
+         << "   --log_grid         \n"
+         << "   --local_channel l (l=0(s),1(p),2(d),3(f),..., default largest possible) \n"
+         << "   --density_mix beta (0 <= beta < 1.0, default 0.75) \n";
     exit(1);
   }
 
@@ -2044,88 +1934,76 @@ int main(int argc, char** argv)
 
   if (parser.Found("casino_pot"))
     nlpp.ReadCASINO_PP(parser.GetArg("casino_pot"));
-  else if (parser.Found("bfd_pot"))
-    nlpp.ReadBFD_PP(parser.GetArg("bfd_pot"));
-  else if (parser.Found("fhi_pot"))
-    nlpp.ReadFHI_PP(parser.GetArg("fhi_pot"));
-  else if (parser.Found("upf_pot"))
-    nlpp.ReadUPF_PP(parser.GetArg("upf_pot"));
-  else if (parser.Found("gamess_pot"))
-    nlpp.ReadGAMESS_PP(parser.GetArg("gamess_pot"));
-  else
-  {
+  else if (parser.Found ("bfd_pot"))
+    nlpp.ReadBFD_PP (parser.GetArg ("bfd_pot"));
+  else if (parser.Found ("fhi_pot"))
+    nlpp.ReadFHI_PP (parser.GetArg ("fhi_pot"));
+  else if (parser.Found ("upf_pot"))
+    nlpp.ReadUPF_PP (parser.GetArg ("upf_pot"));
+  else if (parser.Found ("gamess_pot"))
+    nlpp.ReadGAMESS_PP (parser.GetArg("gamess_pot"));
+  else {
     std::cerr << "Need to specify a potential file with --casino_pot "
-              << "or --bfd_pot or --fhi_pot or --upf_pot or --gamess_pot.\n";
+	 << "or --bfd_pot or --fhi_pot or --upf_pot or --gamess_pot.\n";
     exit(1);
   }
 
   // Now check how the projectors are specified
-  if (!nlpp.HaveProjectors())
-  {
+  if (!nlpp.HaveProjectors()) {
     int numChannels = nlpp.GetNumChannels();
-    if (numChannels > 0)
-    {
-      if (parser.Found("s_ref"))
-        nlpp.CalcProjector(parser.GetArg("s_ref"), 0);
+    if (numChannels > 0) {
+      if (parser.Found ("s_ref"))
+	nlpp.CalcProjector (parser.GetArg("s_ref"), 0);
       else if (parser.Found("casino_us"))
-        nlpp.ReadCASINO_WF(parser.GetArg("casino_us"), 0);
-      else
-      {
-        std::cerr << "Please specify the s-channel projector with either "
-                  << " --s_ref or --casino_us.\n";
-        // exit(-1);
+	nlpp.ReadCASINO_WF(parser.GetArg("casino_us"), 0);
+      else {
+	std::cerr << "Please specify the s-channel projector with either "
+	     << " --s_ref or --casino_us.\n";
+	// exit(-1);
       }
     }
-    if (numChannels > 1)
-    {
-      if (parser.Found("p_ref"))
-        nlpp.CalcProjector(parser.GetArg("p_ref"), 1);
+    if (numChannels > 1) {
+      if (parser.Found ("p_ref"))
+	nlpp.CalcProjector (parser.GetArg("p_ref"), 1);
       else if (parser.Found("casino_up"))
-        nlpp.ReadCASINO_WF(parser.GetArg("casino_up"), 1);
-      else
-      {
-        std::cerr << "Please specify the p-channel projector with either "
-                  << " --p_ref or --casino_up.\n";
-        // exit(-1);
+	nlpp.ReadCASINO_WF(parser.GetArg("casino_up"), 1);
+      else {
+	std::cerr << "Please specify the p-channel projector with either "
+	     << " --p_ref or --casino_up.\n";
+	// exit(-1);
       }
     }
-    if (numChannels > 2)
-    {
-      if (parser.Found("d_ref"))
-        nlpp.CalcProjector(parser.GetArg("d_ref"), 2);
-      else if (parser.Found("casino_ud"))
-        nlpp.ReadCASINO_WF(parser.GetArg("casino_ud"), 2);
-      else
-      {
-        std::cerr << "Please specify the d-channel projector with either "
-                  << " --d_ref or --casino_ud.\n";
-        // exit(-1);
+    if (numChannels > 2) {
+      if (parser.Found ("d_ref"))
+	nlpp.CalcProjector (parser.GetArg("d_ref"), 2);
+      else if(parser.Found("casino_ud"))
+	nlpp.ReadCASINO_WF(parser.GetArg("casino_ud"), 2);
+      else {
+	std::cerr << "Please specify the d-channel projector with either "
+	     << " --d_ref or --casino_ud.\n";
+	// exit(-1);
       }
     }
-    if (numChannels > 3)
-    {
-      if (parser.Found("f_ref"))
-        nlpp.CalcProjector(parser.GetArg("f_ref"), 3);
-      else if (parser.Found("casino_uf"))
-        nlpp.ReadCASINO_WF(parser.GetArg("casino_uf"), 3);
-      else
-      {
-        std::cerr << "Please specify the f-channel projector with either "
-                  << " --f_ref or --casino_uf.\n";
-        // exit(-1);
+    if (numChannels > 3) {
+      if (parser.Found ("f_ref"))
+	nlpp.CalcProjector (parser.GetArg("f_ref"), 3);
+      else if(parser.Found("casino_uf"))
+	nlpp.ReadCASINO_WF(parser.GetArg("casino_uf"), 3);
+      else {
+	std::cerr << "Please specify the f-channel projector with either "
+	     << " --f_ref or --casino_uf.\n";
+	// exit(-1);
       }
     }
-    if (numChannels > 4)
-    {
-      if (parser.Found("g_ref"))
-        nlpp.CalcProjector(parser.GetArg("g_ref"), 4);
-      else if (parser.Found("casino_ug"))
-        nlpp.ReadCASINO_WF(parser.GetArg("casino_ug"), 4);
-      else
-      {
-        std::cerr << "Please specify the g-channel projector with either "
-                  << " --g_ref or --casino_ug.\n";
-        // exit(-1);
+    if (numChannels > 4) {
+      if (parser.Found ("g_ref"))
+	nlpp.CalcProjector (parser.GetArg("g_ref"), 4);
+      else if(parser.Found("casino_ug"))
+	nlpp.ReadCASINO_WF(parser.GetArg("casino_ug"), 4);
+      else {
+	std::cerr << "Please specify the g-channel projector with either "
+	     << " --g_ref or --casino_ug.\n";
+	// exit(-1);
       }
     }
   }
@@ -2135,25 +2013,28 @@ int main(int argc, char** argv)
     nlpp.WriteXML(parser.GetArg("xml"));
   if (parser.Found("tm"))
     nlpp.WriteABINIT(parser.GetArg("tm"));
-  if (parser.Found("upf"))
-    nlpp.WriteUPF(parser.GetArg("upf"));
-  if (parser.Found("fhi"))
-    nlpp.WriteFHI(parser.GetArg("fhi"));
-  if (parser.Found("fpmd"))
-    nlpp.WriteFPMD(parser.GetArg("fpmd"));
-  if (parser.Found("casino"))
-    nlpp.WriteCASINO(parser.GetArg("casino"));
+  if (parser.Found ("upf"))
+    nlpp.WriteUPF (parser.GetArg("upf"));
+  if (parser.Found ("fhi"))
+    nlpp.WriteFHI (parser.GetArg("fhi"));
+  if (parser.Found ("fpmd"))
+    nlpp.WriteFPMD (parser.GetArg("fpmd"));
+  if (parser.Found ("casino"))
+    nlpp.WriteCASINO (parser.GetArg("casino"));
 
-  //   nlpp.WriteXML(xmlFile);
-  //   nlpp.WriteABINIT();
+//   nlpp.WriteXML(xmlFile);
+//   nlpp.WriteABINIT();
   nlpp.WriteASCII();
 
-  //   nlpp.ReadCASINO_PP ("b_pp.data.HF");
-  //   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 0);
-  //   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 1);
-  //   nlpp.ReadCASINO_WF ("awfn.data_s2d1_2D", 2);
-  //   nlpp.WriteXML("test.xml");
+//   nlpp.ReadCASINO_PP ("b_pp.data.HF");
+//   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 0);
+//   nlpp.ReadCASINO_WF ("awfn.data_s2p1_2P", 1);
+//   nlpp.ReadCASINO_WF ("awfn.data_s2d1_2D", 2);
+//   nlpp.WriteXML("test.xml");
 }
+
+
+
 
 
 #include "common/IO.h"
@@ -2167,54 +2048,53 @@ int main(int argc, char** argv)
 //}
 
 
-bool PseudoClass::GetNextState(std::string& state, int& n, int& l, double& occ)
+
+bool
+PseudoClass::GetNextState (std::string &state, int &n, int &l, double &occ)
 {
   if (state.length() <= 0)
     return false;
 
-  if ((state[0] < '1') || (state[0] > '9'))
-  {
+  if ((state[0]<'1') || (state[0] > '9')) {
     std::cerr << "Error parsing reference state.\n";
     abort();
   }
-  n                   = state[0] - '0';
-  std::string channel = state.substr(1, 1);
-  if ((channel != "s") && (channel != "p") && (channel != "d") && (channel != "f") && (channel != "g"))
-  {
+  n = state[0] - '0';
+  std::string channel = state.substr (1,1);
+  if ((channel != "s") && (channel != "p") &&
+      (channel != "d") && (channel != "f") && (channel != "g")) {
     std::cerr << "Unrecognized angular momentum channel in reference state.\n";
     abort();
   }
   l = ChannelRevMap[channel];
   // cerr << "n=" << n << "  l=" << l << endl;
-  if (state[2] != '(')
-  {
+  if (state[2] != '(') {
     std::cerr << "Error parsing occupancy in reference state.\n";
     abort();
   }
-  state.erase(0, 3);
+  state.erase(0,3);
 
   std::string occString;
-  while ((state.length() > 0) && (state[0] != ')'))
-  {
-    occString.append(state.substr(0, 1));
-    state.erase(0, 1);
+  while ((state.length() > 0) && (state[0] != ')')) {
+    occString.append (state.substr(0,1));
+    state.erase(0,1);
   }
-  char* endptr;
-  const char* occStr = occString.c_str();
-  occ                = strtod(occStr, &endptr);
-  if (state[0] != ')')
-  {
+  char *endptr;
+  const char *occStr = occString.c_str();
+  occ = strtod (occStr, &endptr);
+  if (state[0] != ')') {
     std::cerr << "Expected a ')' in parsing reference state.\n";
     abort();
   }
-  state.erase(0, 1);
+  state.erase(0,1);
 
   return true;
 }
 
 
 #include "common/DFTAtom.h"
-void PseudoClass::CalcProjector(std::string refstate, int lchannel)
+void
+PseudoClass::CalcProjector(std::string refstate, int lchannel)
 {
   DFTAtom atom;
   std::string saveState = refstate;
@@ -2225,70 +2105,87 @@ void PseudoClass::CalcProjector(std::string refstate, int lchannel)
   int n, l;
   double occ;
   int lindex = -1;
-  int index  = 0;
-  while (GetNextState(refstate, n, l, occ))
-  {
-    nList.push_back(n);
-    lList.push_back(l);
-    occList.push_back(occ);
+  int index = 0;
+  while (GetNextState(refstate, n, l, occ)) {
+    nList.push_back (n);
+    lList.push_back (l);
+    occList.push_back (occ);
     if (l == lchannel && lindex == -1)
       lindex = index;
     index++;
   }
-  if (lindex == -1)
-  {
-    nList.push_back(lchannel + 1);
+  if (lindex == -1) {
+    nList.push_back(lchannel+1);
     lList.push_back(lchannel);
     occList.push_back(0.0);
-    lindex = nList.size() - 1;
+    lindex = nList.size()-1;
   }
 
   atom.RadialWFs.resize(nList.size());
-  for (int i = 0; i < atom.RadialWFs.size(); i++)
-  {
+  for (int i=0; i<atom.RadialWFs.size(); i++) {
     // atom.RadialWFs(i).n = lList[i]+1;
-    atom.RadialWFs(i).n         = nList[i];
-    atom.RadialWFs(i).l         = lList[i];
+    atom.RadialWFs(i).n = nList[i];
+    atom.RadialWFs(i).l = lList[i];
     atom.RadialWFs(i).Occupancy = occList[i];
-    atom.RadialWFs(i).Energy    = -0.5;
+    atom.RadialWFs(i).Energy = -0.5;
   }
   // Define a grid for solving
-  std::shared_ptr<Grid> optimalGrid = std::make_shared<OptimalGrid>(PseudoCharge, PotentialGrid.End());
-  atom.SetGrid(optimalGrid);
+  std::shared_ptr<Grid> grid = std::make_shared<OptimalGrid>(PseudoCharge, PotentialGrid.End());
+  atom.SetGrid (grid);
   // Set the potential
-  atom.SetBarePot(this);
+  atom.SetBarePot (this);
   // Solve atom
   atom.NewMix = DensityMix;
   std::cerr << "Solving atom for reference state " << saveState << ":\n";
   atom.Solve();
 
   // Now, initialize the channel u functions
-  std::vector<double> ul(PotentialGrid.NumPoints()), rhoAtom(PotentialGrid.NumPoints());
-  for (int i = 0; i < ul.size(); i++)
-  {
-    double r   = PotentialGrid[i];
-    ul[i]      = sqrt(4.0 * M_PI) * atom.RadialWFs(lindex).u(r);
+  std::vector<double> ul(PotentialGrid.NumPoints()),
+    rhoAtom(PotentialGrid.NumPoints());
+  for (int i=0; i<ul.size(); i++) {
+    double r = PotentialGrid[i];
+    ul[i] = sqrt(4.0*M_PI)*atom.RadialWFs(lindex).u(r);
     rhoAtom[i] = atom.rho(r);
   }
-  ChannelPotentials[lchannel].ul.Init(PotentialGrid, ul);
+  ChannelPotentials[lchannel].ul.Init (PotentialGrid, ul);
   ChannelPotentials[lchannel].HasProjector = true;
-  ChannelPotentials[lchannel].Occupation   = occList[lindex];
+  ChannelPotentials[lchannel].Occupation = occList[lindex];
   RhoAtom.Init(PotentialGrid, rhoAtom);
 }
 
-double PseudoClass::V(double r) { return ChannelPotentials[LocalChannel].Vl(r); }
+double
+PseudoClass::V(double r)
+{ return ChannelPotentials[LocalChannel].Vl(r); }
 
-double PseudoClass::dVdr(double r) { return ChannelPotentials[LocalChannel].Vl.Deriv(r); }
+double
+PseudoClass::dVdr(double r)
+{ return ChannelPotentials[LocalChannel].Vl.Deriv(r); }
 
-double PseudoClass::d2Vdr2(double r) { return ChannelPotentials[LocalChannel].Vl.Deriv2(r); }
+double
+PseudoClass::d2Vdr2(double r)
+{ return ChannelPotentials[LocalChannel].Vl.Deriv2(r); }
 
 
-double PseudoClass::V(int l, double r) { return ChannelPotentials[l].Vl(r); }
+double
+PseudoClass::V(int l, double r)
+{
+  return ChannelPotentials[l].Vl(r);
+}
 
-double PseudoClass::dVdr(int l, double r) { return ChannelPotentials[l].Vl.Deriv(r); }
+double
+PseudoClass::dVdr(int l, double r)
+{ return ChannelPotentials[l].Vl.Deriv(r); }
 
-double PseudoClass::d2Vdr2(int l, double r) { return ChannelPotentials[l].Vl.Deriv2(r); }
+double
+PseudoClass::d2Vdr2(int l, double r)
+{ return ChannelPotentials[l].Vl.Deriv2(r); }
 
-void PseudoClass::Write(IOSectionClass& out) {}
+void
+PseudoClass::Write(IOSectionClass &out)
+{
+}
 
-void PseudoClass::Read(IOSectionClass& in) {}
+void
+PseudoClass::Read(IOSectionClass &in)
+{
+}

--- a/src/QMCTools/ppconvert/src/XMLWriterClass2.cc
+++ b/src/QMCTools/ppconvert/src/XMLWriterClass2.cc
@@ -9,6 +9,9 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
+    
+    
+
 
 
 #include "XMLWriterClass2.h"
@@ -18,18 +21,19 @@
 
 XMLAttribute::XMLAttribute(std::string name, std::string content)
 {
-  Name    = name;
+  Name = name;
   Content = content;
 }
 
-XMLAttribute::XMLAttribute(const XMLAttribute& attr)
-{
-  Name    = attr.Name;
-  Content = attr.Content;
+XMLAttribute::XMLAttribute (const XMLAttribute &attr)
+{ 
+  Name = attr.Name; 
+  Content = attr.Content; 
 }
 
 
-void XMLAttribute::Write(std::string& out)
+void
+XMLAttribute::Write(std::string &out)
 {
   std::stringstream str;
   str << Name << "=\"" << Content << "\"";
@@ -37,7 +41,7 @@ void XMLAttribute::Write(std::string& out)
 }
 
 
-XMLElement::XMLElement(const XMLElement& elem)
+XMLElement::XMLElement(const XMLElement &elem)
 {
   Attributes = elem.Attributes;
   Children   = elem.Children;
@@ -46,27 +50,27 @@ XMLElement::XMLElement(const XMLElement& elem)
   Level      = elem.Level;
 }
 
-void XMLElement::Indent(std::ostream& out)
+void 
+XMLElement::Indent(std::ostream &out)
 {
-  for (int i = 0; i < Level; i++)
+  for (int i=0; i<Level; i++)
     out << "  ";
 }
 
 
-void XMLElement::Write(std::ostream& out)
+void 
+XMLElement::Write(std::ostream &out)
 {
   Indent(out);
   out << "<" << Name;
-  int lineCount = Name.size() + 1;
-  for (int i = 0; i < Attributes.size(); i++)
-  {
+  int lineCount = Name.size()+1;
+  for (int i=0; i<Attributes.size(); i++) {
     out << " ";
     std::string str;
     Attributes[i]->Write(str);
-    if (lineCount + str.size() + 2 * Level > 73)
-    {
+    if (lineCount + str.size() + 2*Level > 73) {
       out << "\n";
-      Indent(out);
+      Indent (out);
       out << " ";
       lineCount = 1;
     }
@@ -74,142 +78,155 @@ void XMLElement::Write(std::ostream& out)
     out << str;
   }
   int numLines = 0;
-  for (int i = 0; i < Content.size(); i++)
+  for (int i=0; i<Content.size(); i++)
     numLines += (Content[i] == '\n');
 
-  if (Content == "" && Children.size() == 0)
+  if (Content == "" && Children.size()==0)
     out << "/>\n";
-  else
-  {
+  else {
     out << ">";
     if (numLines > 0 || Children.size() > 0)
       out << "\n";
     out << Content;
-    for (int i = 0; i < Children.size(); i++)
+    for (int i=0; i<Children.size(); i++)
       Children[i]->Write(out);
-    if (numLines > 0 || Children.size() > 0)
+    if (numLines > 0 || Children.size()>0)
       Indent(out);
     out << "</" << Name << ">\n";
   }
 }
+    
 
-
-void XMLElement::AddContent(std::vector<double>& data)
+void 
+XMLElement::AddContent(std::vector<double> &data)
 {
   std::stringstream str;
   str.setf(std::ios_base::scientific, std::ios_base::floatfield);
   str << std::setprecision(14);
-  for (int i = 0; i < data.size(); i++)
-  {
-    if ((i % 3 == 0))
+  for (int i=0; i<data.size(); i++) {
+    if ((i%3 == 0)) 
       Indent(str);
     str.width(22);
     str << data[i];
-    if ((i % 3) == 2)
+    if ((i%3) == 2)
       str << "\n";
   }
-  if ((data.size() % 3) != 0)
-    str << "\n";
+  if ((data.size()%3) != 0)
+   str << "\n";
   Content += str.str();
 }
 
 
-bool XMLWriterClass::StartDocument(std::string fname, std::string version, std::string encoding, std::string standalone)
+
+bool
+XMLWriterClass::StartDocument(std::string fname, std::string version,
+			      std::string encoding, std::string standalone)
 {
-  Out.open(fname.c_str(), std::ofstream::out | std::ofstream::trunc);
+  Out.open (fname.c_str(),std::ofstream::out | std::ofstream::trunc);
   if (!Out.is_open())
     return false;
   if (version == "")
     version = "1.0";
   if (encoding == "")
     encoding = "UTF-8";
-
-  Out << "<?xml version=\"" << version << "\" encoding=\"" << encoding << "\"?>\n";
+  
+  Out << "<?xml version=\"" << version 
+      << "\" encoding=\""   << encoding << "\"?>\n";
 
   return true;
 }
 
-bool XMLWriterClass::EndDocument()
+bool
+XMLWriterClass::EndDocument()
 {
-  if (Elements.size() <= 0)
+  if (Elements.size() <=0)
     return false;
   Elements[0]->Write(Out);
   return true;
 }
 
-bool XMLWriterClass::StartElement(std::string name)
+bool
+XMLWriterClass::StartElement(std::string name)
 {
   int level = Elements.size();
-
+  
   auto elem = std::make_shared<XMLElement>(name, level);
   if (level > 0)
-    Elements.back()->AddElement(elem);
+    Elements.back()->AddElement (elem);
   Elements.push_back(elem);
   return true;
 }
 
-bool XMLWriterClass::EndElement()
+bool
+XMLWriterClass::EndElement()
 {
   if (Elements.size() > 1)
     Elements.pop_back();
   return true;
 }
 
-bool XMLWriterClass::FullEndElement()
+bool
+XMLWriterClass::FullEndElement()
 {
   Elements.pop_back();
   return true;
 }
 
-bool XMLWriterClass::WriteAttribute(std::string name, std::string content)
+bool
+XMLWriterClass::WriteAttribute (std::string name, std::string content)
 {
   auto attr = std::make_shared<XMLAttribute>(name, content);
-  Elements.back()->AddAttribute(attr);
+  Elements.back()->AddAttribute (attr);
   return true;
 }
 
-bool XMLWriterClass::WriteAttribute(std::string name, double val, bool scientific)
+bool
+XMLWriterClass::WriteAttribute (std::string name, double val, bool scientific)
 {
   std::stringstream content;
-  if (scientific)
-  {
+  if (scientific) {
     content.setf(std::ios_base::scientific, std::ios_base::floatfield);
     content << std::setprecision(14);
   }
   content << val;
   auto attr = std::make_shared<XMLAttribute>(name, content.str());
-  Elements.back()->AddAttribute(attr);
+  Elements.back()->AddAttribute (attr);
   return true;
 }
 
-bool XMLWriterClass::WriteAttribute(std::string name, int val)
+bool
+XMLWriterClass::WriteAttribute (std::string name, int val)
 {
   std::stringstream content;
   content << val;
   auto attr = std::make_shared<XMLAttribute>(name, content.str());
-  Elements.back()->AddAttribute(attr);
+  Elements.back()->AddAttribute (attr);
   return true;
 }
 
-bool XMLWriterClass::WriteData(std::vector<double> data)
+bool
+XMLWriterClass::WriteData(std::vector<double> data)
 {
-  Elements.back()->AddContent(data);
+  Elements.back()->AddContent (data);
   return true;
 }
 
-bool XMLWriterClass::WriteData(std::string data)
+bool
+XMLWriterClass::WriteData(std::string data)
 {
-  Elements.back()->AddContent(data);
+  Elements.back()->AddContent (data);
   return true;
 }
 
 
-bool XMLWriterClass::WriteElement(std::string name, std::vector<double> data)
+bool
+XMLWriterClass::WriteElement (std::string name, std::vector<double> data)
 {
   int level = Elements.size();
   auto elem = std::make_shared<XMLElement>(name, level);
-  elem->AddContent(data);
+  elem->AddContent (data);
   if (level > 0)
-    Elements.back()->AddElement(elem);
+    Elements.back()->AddElement (elem);
   return true;
 }
+

--- a/src/QMCTools/ppconvert/src/XMLWriterClass2.cc
+++ b/src/QMCTools/ppconvert/src/XMLWriterClass2.cc
@@ -9,9 +9,6 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
-
 
 
 #include "XMLWriterClass2.h"
@@ -21,19 +18,18 @@
 
 XMLAttribute::XMLAttribute(std::string name, std::string content)
 {
-  Name = name;
+  Name    = name;
   Content = content;
 }
 
-XMLAttribute::XMLAttribute (const XMLAttribute &attr)
-{ 
-  Name = attr.Name; 
-  Content = attr.Content; 
+XMLAttribute::XMLAttribute(const XMLAttribute& attr)
+{
+  Name    = attr.Name;
+  Content = attr.Content;
 }
 
 
-void
-XMLAttribute::Write(std::string &out)
+void XMLAttribute::Write(std::string& out)
 {
   std::stringstream str;
   str << Name << "=\"" << Content << "\"";
@@ -41,7 +37,7 @@ XMLAttribute::Write(std::string &out)
 }
 
 
-XMLElement::XMLElement(const XMLElement &elem)
+XMLElement::XMLElement(const XMLElement& elem)
 {
   Attributes = elem.Attributes;
   Children   = elem.Children;
@@ -50,27 +46,27 @@ XMLElement::XMLElement(const XMLElement &elem)
   Level      = elem.Level;
 }
 
-void 
-XMLElement::Indent(std::ostream &out)
+void XMLElement::Indent(std::ostream& out)
 {
-  for (int i=0; i<Level; i++)
+  for (int i = 0; i < Level; i++)
     out << "  ";
 }
 
 
-void 
-XMLElement::Write(std::ostream &out)
+void XMLElement::Write(std::ostream& out)
 {
   Indent(out);
   out << "<" << Name;
-  int lineCount = Name.size()+1;
-  for (int i=0; i<Attributes.size(); i++) {
+  int lineCount = Name.size() + 1;
+  for (int i = 0; i < Attributes.size(); i++)
+  {
     out << " ";
     std::string str;
     Attributes[i]->Write(str);
-    if (lineCount + str.size() + 2*Level > 73) {
+    if (lineCount + str.size() + 2 * Level > 73)
+    {
       out << "\n";
-      Indent (out);
+      Indent(out);
       out << " ";
       lineCount = 1;
     }
@@ -78,155 +74,142 @@ XMLElement::Write(std::ostream &out)
     out << str;
   }
   int numLines = 0;
-  for (int i=0; i<Content.size(); i++)
+  for (int i = 0; i < Content.size(); i++)
     numLines += (Content[i] == '\n');
 
-  if (Content == "" && Children.size()==0)
+  if (Content == "" && Children.size() == 0)
     out << "/>\n";
-  else {
+  else
+  {
     out << ">";
     if (numLines > 0 || Children.size() > 0)
       out << "\n";
     out << Content;
-    for (int i=0; i<Children.size(); i++)
+    for (int i = 0; i < Children.size(); i++)
       Children[i]->Write(out);
-    if (numLines > 0 || Children.size()>0)
+    if (numLines > 0 || Children.size() > 0)
       Indent(out);
     out << "</" << Name << ">\n";
   }
 }
-    
 
-void 
-XMLElement::AddContent(std::vector<double> &data)
+
+void XMLElement::AddContent(std::vector<double>& data)
 {
   std::stringstream str;
   str.setf(std::ios_base::scientific, std::ios_base::floatfield);
   str << std::setprecision(14);
-  for (int i=0; i<data.size(); i++) {
-    if ((i%3 == 0)) 
+  for (int i = 0; i < data.size(); i++)
+  {
+    if ((i % 3 == 0))
       Indent(str);
     str.width(22);
     str << data[i];
-    if ((i%3) == 2)
+    if ((i % 3) == 2)
       str << "\n";
   }
-  if ((data.size()%3) != 0)
-   str << "\n";
+  if ((data.size() % 3) != 0)
+    str << "\n";
   Content += str.str();
 }
 
 
-
-bool
-XMLWriterClass::StartDocument(std::string fname, std::string version,
-			      std::string encoding, std::string standalone)
+bool XMLWriterClass::StartDocument(std::string fname, std::string version, std::string encoding, std::string standalone)
 {
-  Out.open (fname.c_str(),std::ofstream::out | std::ofstream::trunc);
+  Out.open(fname.c_str(), std::ofstream::out | std::ofstream::trunc);
   if (!Out.is_open())
     return false;
   if (version == "")
     version = "1.0";
   if (encoding == "")
     encoding = "UTF-8";
-  
-  Out << "<?xml version=\"" << version 
-      << "\" encoding=\""   << encoding << "\"?>\n";
+
+  Out << "<?xml version=\"" << version << "\" encoding=\"" << encoding << "\"?>\n";
 
   return true;
 }
 
-bool
-XMLWriterClass::EndDocument()
+bool XMLWriterClass::EndDocument()
 {
-  if (Elements.size() <=0)
+  if (Elements.size() <= 0)
     return false;
   Elements[0]->Write(Out);
   return true;
 }
 
-bool
-XMLWriterClass::StartElement(std::string name)
+bool XMLWriterClass::StartElement(std::string name)
 {
   int level = Elements.size();
-  
-  XMLElement* elem = new XMLElement(name, level);
+
+  auto elem = std::make_shared<XMLElement>(name, level);
   if (level > 0)
-    Elements.back()->AddElement (elem);
+    Elements.back()->AddElement(elem);
   Elements.push_back(elem);
   return true;
 }
 
-bool
-XMLWriterClass::EndElement()
+bool XMLWriterClass::EndElement()
 {
   if (Elements.size() > 1)
     Elements.pop_back();
   return true;
 }
 
-bool
-XMLWriterClass::FullEndElement()
+bool XMLWriterClass::FullEndElement()
 {
   Elements.pop_back();
   return true;
 }
 
-bool
-XMLWriterClass::WriteAttribute (std::string name, std::string content)
+bool XMLWriterClass::WriteAttribute(std::string name, std::string content)
 {
-  XMLAttribute *attr = new XMLAttribute (name, content);
-  Elements.back()->AddAttribute (attr);
+  auto attr = std::make_shared<XMLAttribute>(name, content);
+  Elements.back()->AddAttribute(attr);
   return true;
 }
 
-bool
-XMLWriterClass::WriteAttribute (std::string name, double val, bool scientific)
+bool XMLWriterClass::WriteAttribute(std::string name, double val, bool scientific)
 {
   std::stringstream content;
-  if (scientific) {
+  if (scientific)
+  {
     content.setf(std::ios_base::scientific, std::ios_base::floatfield);
     content << std::setprecision(14);
   }
   content << val;
-  XMLAttribute *attr = new XMLAttribute (name, content.str());
-  Elements.back()->AddAttribute (attr);
+  auto attr = std::make_shared<XMLAttribute>(name, content.str());
+  Elements.back()->AddAttribute(attr);
   return true;
 }
 
-bool
-XMLWriterClass::WriteAttribute (std::string name, int val)
+bool XMLWriterClass::WriteAttribute(std::string name, int val)
 {
   std::stringstream content;
   content << val;
-  XMLAttribute *attr = new XMLAttribute (name, content.str());
-  Elements.back()->AddAttribute (attr);
+  auto attr = std::make_shared<XMLAttribute>(name, content.str());
+  Elements.back()->AddAttribute(attr);
   return true;
 }
 
-bool
-XMLWriterClass::WriteData(std::vector<double> data)
+bool XMLWriterClass::WriteData(std::vector<double> data)
 {
-  Elements.back()->AddContent (data);
+  Elements.back()->AddContent(data);
   return true;
 }
 
-bool
-XMLWriterClass::WriteData(std::string data)
+bool XMLWriterClass::WriteData(std::string data)
 {
-  Elements.back()->AddContent (data);
+  Elements.back()->AddContent(data);
   return true;
 }
 
 
-bool
-XMLWriterClass::WriteElement (std::string name, std::vector<double> data)
+bool XMLWriterClass::WriteElement(std::string name, std::vector<double> data)
 {
   int level = Elements.size();
-  XMLElement *elem = new XMLElement (name, level);
-  elem->AddContent (data);
+  auto elem = std::make_shared<XMLElement>(name, level);
+  elem->AddContent(data);
   if (level > 0)
-    Elements.back()->AddElement (elem);
+    Elements.back()->AddElement(elem);
   return true;
 }
-

--- a/src/QMCTools/ppconvert/src/XMLWriterClass2.h
+++ b/src/QMCTools/ppconvert/src/XMLWriterClass2.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <memory> // std::shared_ptr
 
 
 class XMLAttribute
@@ -38,8 +39,8 @@ public:
 
 class XMLElement
 {
-  std::vector<XMLAttribute*> Attributes;
-  std::vector<XMLElement*> Children;
+  std::vector<std::shared_ptr<XMLAttribute>> Attributes;
+  std::vector<std::shared_ptr<XMLElement>> Children;
   std::string Name, Content;
   int Level;
   void Indent(std::ostream& out);
@@ -49,9 +50,9 @@ public:
 
   inline int GetLevel() { return Level; }
 
-  void AddElement(XMLElement* elem) { Children.push_back(elem); }
+  void AddElement(std::shared_ptr<XMLElement>& elem) { Children.push_back(elem); }
 
-  void AddAttribute(XMLAttribute* attr) { Attributes.push_back(attr); }
+  void AddAttribute(std::shared_ptr<XMLAttribute>& attr) { Attributes.push_back(attr); }
 
   void AddContent(std::string content) { Content += content; }
 
@@ -70,7 +71,7 @@ public:
 class XMLWriterClass
 {
 private:
-  std::vector<XMLElement*> Elements;
+  std::vector<std::shared_ptr<XMLElement>> Elements;
   void Write();
   std::ofstream Out;
 

--- a/src/QMCTools/ppconvert/src/common/AtomBase.h
+++ b/src/QMCTools/ppconvert/src/common/AtomBase.h
@@ -18,6 +18,8 @@
 
 #include "RadialWF.h"
 
+#include <memory> // std::shared_ptr
+
 typedef enum
 {
   DFTType,
@@ -28,7 +30,7 @@ typedef enum
 class Atom
 {
 protected:
-  Grid* grid;
+  std::shared_ptr<Grid> grid;
 
 public:
   Array<RadialWF, 1> RadialWFs;
@@ -38,8 +40,8 @@ public:
   virtual void Solve()                                                                        = 0;
   virtual void Write(IOSectionClass& out)                                                     = 0;
   virtual void Read(IOSectionClass& in)                                                       = 0;
-  virtual void SetGrid(Grid* newGrid)                                                         = 0;
-  inline Grid* GetGrid() { return grid; }
+  virtual void SetGrid(std::shared_ptr<Grid>& newGrid)                                        = 0;
+  inline Grid* GetGrid() { return grid.get(); }
   inline double NumElecs();
   virtual void SetBarePot(Potential* pot) = 0;
 };

--- a/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
+++ b/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
@@ -39,7 +39,7 @@ private:
 
 public:
   int NumParams;
-  Grid* grid;
+  std::shared_ptr<Grid> grid;
   /// The values of the derivative of the represented function on the
   /// boundary.  If each value is greater that 1e30, we compute
   /// boundary conditions assuming that the second derivative is zero at
@@ -61,7 +61,7 @@ public:
 
   /// Initialize the cubic spline.  See notes about start and end
   /// deriv above.
-  inline void Init(Grid* NewGrid, Array<double, 1> NewYs, double startderiv, double endderiv)
+  inline void Init(std::shared_ptr<Grid>& NewGrid, Array<double, 1> NewYs, double startderiv, double endderiv)
   {
     StartDeriv = startderiv;
     EndDeriv   = endderiv;
@@ -82,17 +82,17 @@ public:
 
   /// Simplified form which assumes that the second derivative at both
   /// boundaries are zero.
-  inline void Init(Grid* NewGrid, Array<double, 1> NewYs) { Init(NewGrid, NewYs, 5.0e30, 5.0e30); }
+  inline void Init(std::shared_ptr<Grid>& NewGrid, Array<double, 1> NewYs) { Init(NewGrid, NewYs, 5.0e30, 5.0e30); }
 
   /// Simplified constructor.
-  inline CubicSplineCommon(Grid* NewGrid, Array<double, 1> NewYs)
+  inline CubicSplineCommon(std::shared_ptr<Grid>& NewGrid, Array<double, 1> NewYs)
   {
     StartDeriv = EndDeriv = 5.0e30;
     Init(NewGrid, NewYs, 5.0e30, 5.0e30);
   }
 
   /// Full constructor.
-  inline CubicSplineCommon(Grid* NewGrid, Array<double, 1> NewYs, double startderiv, double endderiv)
+  inline CubicSplineCommon(std::shared_ptr<Grid>& NewGrid, Array<double, 1> NewYs, double startderiv, double endderiv)
   {
     Init(NewGrid, NewYs, startderiv, endderiv);
     Update();
@@ -139,11 +139,11 @@ public:
   /// Trivial constructor
   CubicSplineCommon()
   {
-    UpToDate = 0;
-    NumParams = 0;
+    UpToDate   = 0;
+    NumParams  = 0;
     StartDeriv = 0;
-    EndDeriv = 0;
-    grid     = NULL;
+    EndDeriv   = 0;
+    grid       = NULL;
   }
 };
 

--- a/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
+++ b/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
@@ -139,11 +139,11 @@ public:
   /// Trivial constructor
   CubicSplineCommon()
   {
-    UpToDate   = 0;
-    NumParams  = 0;
+    UpToDate = 0;
+    NumParams = 0;
     StartDeriv = 0;
-    EndDeriv   = 0;
-    grid       = NULL;
+    EndDeriv = 0;
+    grid     = NULL;
   }
 };
 

--- a/src/QMCTools/ppconvert/src/common/DFTAtom.cc
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.cc
@@ -8,8 +8,8 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
@@ -17,10 +17,7 @@
 #include "RungeKutta.h"
 #include "Functionals.h"
 
-AtomType DFTAtom::Type()
-{
-  return (DFTType);
-}
+AtomType DFTAtom::Type() { return (DFTType); }
 
 void DFTAtom::UpdateVHXC()
 {
@@ -28,20 +25,22 @@ void DFTAtom::UpdateVHXC()
   UpdateHartree();
   UpdateExCorr();
 
-  for (int i=0; i < grid->NumPoints; i++)
+  for (int i = 0; i < grid->NumPoints; i++)
     V.HXC(i) = Hartree(i) + ExCorr(i);
 }
 
 /// Radial WFs must be normalized before calling this function
 void DFTAtom::UpdateChargeDensity()
 {
-  for (int i=0; i<grid->NumPoints; i++) {
+  for (int i = 0; i < grid->NumPoints; i++)
+  {
     ChargeDensity(i) = 0.0;
-    double r = (*grid)(i);
-    double rinv2 = 1.0/(r*r);
-    for (int j=0; j<RadialWFs.size(); j++) {
+    double r         = (*grid)(i);
+    double rinv2     = 1.0 / (r * r);
+    for (int j = 0; j < RadialWFs.size(); j++)
+    {
       double u = RadialWFs(j).u(i);
-      ChargeDensity(i) += RadialWFs(j).Occupancy * u*u * rinv2;
+      ChargeDensity(i) += RadialWFs(j).Occupancy * u * u * rinv2;
     }
   }
 }
@@ -49,51 +48,56 @@ void DFTAtom::UpdateChargeDensity()
 
 class HartreeDeriv1
 {
-  DFTAtom &atom;
-public:
-  inline double operator()(double r, double sum)
-  { return atom.Hartree1(r,sum); }
+  DFTAtom& atom;
 
-  HartreeDeriv1(DFTAtom &newAtom) : atom(newAtom) 
-  { /* Do nothing */ }
+public:
+  inline double operator()(double r, double sum) { return atom.Hartree1(r, sum); }
+
+  HartreeDeriv1(DFTAtom& newAtom) : atom(newAtom)
+  { /* Do nothing */
+  }
 };
 
 class HartreeDeriv2
 {
-  DFTAtom &atom;
-public:
-  inline double operator()(double r, double sum)
-  { return atom.Hartree2(r,sum); }
+  DFTAtom& atom;
 
-  HartreeDeriv2(DFTAtom &newAtom) : atom(newAtom) 
-  { /* Do nothing */ }
+public:
+  inline double operator()(double r, double sum) { return atom.Hartree2(r, sum); }
+
+  HartreeDeriv2(DFTAtom& newAtom) : atom(newAtom)
+  { /* Do nothing */
+  }
 };
 
 
 void DFTAtom::UpdateHartree()
 {
   int N = grid->NumPoints;
-  
+
   HartreeDeriv1 H1(*this);
   HartreeDeriv2 H2(*this);
-  RungeKutta<HartreeDeriv1,double> integrator1(H1);
-  RungeKutta<HartreeDeriv2,double> integrator2(H2);
-  temp(0) = 0.0;  temp2(0) = 0.0;
-  integrator1.Integrate(*grid, 0, N-1, temp);
-  integrator2.Integrate(*grid, 0, N-1, temp2);
+  RungeKutta<HartreeDeriv1, double> integrator1(H1);
+  RungeKutta<HartreeDeriv2, double> integrator2(H2);
+  temp(0)  = 0.0;
+  temp2(0) = 0.0;
+  integrator1.Integrate(*grid, 0, N - 1, temp);
+  integrator2.Integrate(*grid, 0, N - 1, temp2);
 
-  for (int i=0; i<N; i++) {
-    double r = (*grid)(i);
-    Hartree(i) = 4.0*M_PI*(temp(i)/r + (temp2(N-1)-temp2(i)));
+  for (int i = 0; i < N; i++)
+  {
+    double r   = (*grid)(i);
+    Hartree(i) = 4.0 * M_PI * (temp(i) / r + (temp2(N - 1) - temp2(i)));
   }
 }
 
 void DFTAtom::UpdateExCorr()
 {
   int N = grid->NumPoints;
-  for (int i=0; i<N; i++) {
+  for (int i = 0; i < N; i++)
+  {
     double Vxcup, Vxcdown;
-    double upCharge = 0.5*ChargeDensity(i);
+    double upCharge   = 0.5 * ChargeDensity(i);
     double downCharge = upCharge;
     CPPExCorr(upCharge, downCharge, Vxcup, Vxcdown);
     //    FortranExCorr(upCharge, downCharge, Vxcup, Vxcdown);
@@ -102,26 +106,26 @@ void DFTAtom::UpdateExCorr()
 }
 
 
-void DFTAtom::SetGrid(Grid *newgrid)
+void DFTAtom::SetGrid(std::shared_ptr<Grid>& newgrid)
 {
-  grid = newgrid;
+  grid  = newgrid;
   int N = grid->NumPoints;
   temp.resize(N);
   temp2.resize(N);
   temp = 0.0;
   V.HXC.Init(grid, temp);
-  ChargeDensity.Init(grid,temp);
+  ChargeDensity.Init(grid, temp);
   Hartree.Init(grid, temp);
-  ExCorr.Init(grid,temp);
-  for (int i=0; i<RadialWFs.size(); i++)
+  ExCorr.Init(grid, temp);
+  for (int i = 0; i < RadialWFs.size(); i++)
     RadialWFs(i).SetGrid(grid);
 }
 
-void DFTAtom::SetBarePot(Potential *newPot)
+void DFTAtom::SetBarePot(Potential* newPot)
 {
-  BarePot = newPot;
+  BarePot   = newPot;
   V.BarePot = BarePot;
-  for (int i=0; i<RadialWFs.size(); i++)
+  for (int i = 0; i < RadialWFs.size(); i++)
     RadialWFs(i).SetPotential(&V);
 }
 
@@ -129,7 +133,7 @@ void DFTAtom::SetBarePot(Potential *newPot)
 //void
 //DFTAtom::SolveInit()
 //{
-//  int N = grid->NumPoints; 
+//  int N = grid->NumPoints;
 //  // Just rename temp and temp2 for clarity
 //  Array<double,1> &oldCharge = temp;
 //  Array<double,1> &newCharge = temp2;
@@ -138,7 +142,7 @@ void DFTAtom::SetBarePot(Potential *newPot)
 //  for (int i=0; i<N; i++)
 //    V.HXC(i) = 0.0;
 
-//  OldEnergies.resize(RadialWFs.size());  
+//  OldEnergies.resize(RadialWFs.size());
 //  // Now solve radial equations
 //  for (int i=0; i<RadialWFs.size(); i++) {
 //    RadialWFs(i).Solve();
@@ -157,7 +161,7 @@ void DFTAtom::SetBarePot(Potential *newPot)
 //double
 //DFTAtom::SolveIter()
 //{
-//  int N = grid->NumPoints; 
+//  int N = grid->NumPoints;
 //  // Just rename temp and temp2 for clarity
 //  Array<double,1> &oldCharge = temp;
 //  Array<double,1> &newCharge = temp2;
@@ -168,7 +172,7 @@ void DFTAtom::SetBarePot(Potential *newPot)
 //  UpdateExCorr();
 //  for (int i=0; i < grid->NumPoints; i++)
 //    V.HXC(i) = Hartree(i) + ExCorr(i);
-//  
+//
 //  double maxDiff = 0.0;
 //  for (int i=0; i<RadialWFs.size(); i++) {
 //    RadialWFs(i).Solve();
@@ -185,18 +189,19 @@ void DFTAtom::SetBarePot(Potential *newPot)
 
 void DFTAtom::Solve()
 {
-  int N = grid->NumPoints; 
+  int N = grid->NumPoints;
   // Just rename temp and temp2 for clarity
-  Array<double,1> &oldCharge = temp;
-  Array<double,1> &newCharge = temp2;
+  Array<double, 1>& oldCharge = temp;
+  Array<double, 1>& newCharge = temp2;
 
   // First, zero out screening
-  for (int i=0; i<N; i++)
+  for (int i = 0; i < N; i++)
     V.HXC(i) = 0.0;
 
-  Array<double,1> oldEnergies(RadialWFs.size());  
+  Array<double, 1> oldEnergies(RadialWFs.size());
   // Now solve radial equations
-  for (int i=0; i<RadialWFs.size(); i++) {
+  for (int i = 0; i < RadialWFs.size(); i++)
+  {
     RadialWFs(i).Solve();
     // fprintf (stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
     oldEnergies(i) = RadialWFs(i).Energy;
@@ -211,56 +216,57 @@ void DFTAtom::Solve()
 
   bool done = false;
 
-  while (!done) {
-    for (int i=0; i<N; i++)
-      ChargeDensity(i) = NewMix*(newCharge(i)) + (1.0-NewMix)*oldCharge(i);
+  while (!done)
+  {
+    for (int i = 0; i < N; i++)
+      ChargeDensity(i) = NewMix * (newCharge(i)) + (1.0 - NewMix) * oldCharge(i);
     UpdateHartree();
     UpdateExCorr();
-    for (int i=0; i < grid->NumPoints; i++)
+    for (int i = 0; i < grid->NumPoints; i++)
       V.HXC(i) = Hartree(i) + ExCorr(i);
 
     done = true;
-    for (int i=0; i<RadialWFs.size(); i++) {
+    for (int i = 0; i < RadialWFs.size(); i++)
+    {
       RadialWFs(i).Solve();
-      if (fabs(oldEnergies(i)-RadialWFs(i).Energy) > 1.0e-8)
-	done = false;
+      if (fabs(oldEnergies(i) - RadialWFs(i).Energy) > 1.0e-8)
+        done = false;
       oldEnergies(i) = RadialWFs(i).Energy;
     }
-    for (int i=0; i<RadialWFs.size(); i++)
-      fprintf (stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
+    for (int i = 0; i < RadialWFs.size(); i++)
+      fprintf(stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
     oldCharge = ChargeDensity.Data();
     UpdateChargeDensity();
     newCharge = ChargeDensity.Data();
   }
-  
-
 }
 
 
-void DFTAtom::Write(IOSectionClass &out)
+void DFTAtom::Write(IOSectionClass& out)
 {
-  out.WriteVar ("Type", "DFT");
+  out.WriteVar("Type", "DFT");
   out.NewSection("Grid");
   grid->Write(out);
   out.CloseSection();
 
-  for (int i=0; i<RadialWFs.size(); i++) {
+  for (int i = 0; i < RadialWFs.size(); i++)
+  {
     out.NewSection("RadialWF");
     RadialWFs(i).Write(out);
     out.CloseSection();
   }
 
-  out.WriteVar ("ChargeDensity", ChargeDensity.Data());
-  out.WriteVar ("Hartree", Hartree.Data());
-  out.WriteVar ("ExCorr", ExCorr.Data());
+  out.WriteVar("ChargeDensity", ChargeDensity.Data());
+  out.WriteVar("Hartree", Hartree.Data());
+  out.WriteVar("ExCorr", ExCorr.Data());
   out.NewSection("Potential");
   BarePot->Write(out);
   out.CloseSection();
-  out.WriteVar ("NewMix", NewMix);
+  out.WriteVar("NewMix", NewMix);
 }
 
 
-void DFTAtom::Read(IOSectionClass &in) 
+void DFTAtom::Read(IOSectionClass& in)
 {
   assert(in.OpenSection("Grid"));
   grid = ReadGrid(in);
@@ -274,22 +280,22 @@ void DFTAtom::Read(IOSectionClass &in)
   int numRadialWFs = in.CountSections("RadialWF");
   RadialWFs.resize(numRadialWFs);
   SetGrid(grid);
-  in.ReadVar ("ChargeDensity", ChargeDensity.Data());
-  in.ReadVar ("Hartree", Hartree.Data());
-  in.ReadVar ("ExCorr", ExCorr.Data());
-  for (int i=0; i<V.HXC.size(); i++)
-    V.HXC(i) = Hartree(i)+ExCorr(i);
+  in.ReadVar("ChargeDensity", ChargeDensity.Data());
+  in.ReadVar("Hartree", Hartree.Data());
+  in.ReadVar("ExCorr", ExCorr.Data());
+  for (int i = 0; i < V.HXC.size(); i++)
+    V.HXC(i) = Hartree(i) + ExCorr(i);
 
   double charge = 0.0;
-  for (int i=0; i<numRadialWFs; i++) {
-    RadialWFs(i).SetGrid (grid);
-    RadialWFs(i).SetPotential (&V);
-    assert (in.OpenSection("RadialWF", i));
+  for (int i = 0; i < numRadialWFs; i++)
+  {
+    RadialWFs(i).SetGrid(grid);
+    RadialWFs(i).SetPotential(&V);
+    assert(in.OpenSection("RadialWF", i));
     RadialWFs(i).Read(in);
     charge += RadialWFs(i).Occupancy;
     in.CloseSection();
   }
   V.Charge = charge;
-  assert (in.ReadVar("NewMix", NewMix));
+  assert(in.ReadVar("NewMix", NewMix));
 }
-

--- a/src/QMCTools/ppconvert/src/common/DFTAtom.cc
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.cc
@@ -8,8 +8,8 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-
-
+    
+    
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
@@ -17,7 +17,10 @@
 #include "RungeKutta.h"
 #include "Functionals.h"
 
-AtomType DFTAtom::Type() { return (DFTType); }
+AtomType DFTAtom::Type()
+{
+  return (DFTType);
+}
 
 void DFTAtom::UpdateVHXC()
 {
@@ -25,22 +28,20 @@ void DFTAtom::UpdateVHXC()
   UpdateHartree();
   UpdateExCorr();
 
-  for (int i = 0; i < grid->NumPoints; i++)
+  for (int i=0; i < grid->NumPoints; i++)
     V.HXC(i) = Hartree(i) + ExCorr(i);
 }
 
 /// Radial WFs must be normalized before calling this function
 void DFTAtom::UpdateChargeDensity()
 {
-  for (int i = 0; i < grid->NumPoints; i++)
-  {
+  for (int i=0; i<grid->NumPoints; i++) {
     ChargeDensity(i) = 0.0;
-    double r         = (*grid)(i);
-    double rinv2     = 1.0 / (r * r);
-    for (int j = 0; j < RadialWFs.size(); j++)
-    {
+    double r = (*grid)(i);
+    double rinv2 = 1.0/(r*r);
+    for (int j=0; j<RadialWFs.size(); j++) {
       double u = RadialWFs(j).u(i);
-      ChargeDensity(i) += RadialWFs(j).Occupancy * u * u * rinv2;
+      ChargeDensity(i) += RadialWFs(j).Occupancy * u*u * rinv2;
     }
   }
 }
@@ -48,56 +49,51 @@ void DFTAtom::UpdateChargeDensity()
 
 class HartreeDeriv1
 {
-  DFTAtom& atom;
-
+  DFTAtom &atom;
 public:
-  inline double operator()(double r, double sum) { return atom.Hartree1(r, sum); }
+  inline double operator()(double r, double sum)
+  { return atom.Hartree1(r,sum); }
 
-  HartreeDeriv1(DFTAtom& newAtom) : atom(newAtom)
-  { /* Do nothing */
-  }
+  HartreeDeriv1(DFTAtom &newAtom) : atom(newAtom) 
+  { /* Do nothing */ }
 };
 
 class HartreeDeriv2
 {
-  DFTAtom& atom;
-
+  DFTAtom &atom;
 public:
-  inline double operator()(double r, double sum) { return atom.Hartree2(r, sum); }
+  inline double operator()(double r, double sum)
+  { return atom.Hartree2(r,sum); }
 
-  HartreeDeriv2(DFTAtom& newAtom) : atom(newAtom)
-  { /* Do nothing */
-  }
+  HartreeDeriv2(DFTAtom &newAtom) : atom(newAtom) 
+  { /* Do nothing */ }
 };
 
 
 void DFTAtom::UpdateHartree()
 {
   int N = grid->NumPoints;
-
+  
   HartreeDeriv1 H1(*this);
   HartreeDeriv2 H2(*this);
-  RungeKutta<HartreeDeriv1, double> integrator1(H1);
-  RungeKutta<HartreeDeriv2, double> integrator2(H2);
-  temp(0)  = 0.0;
-  temp2(0) = 0.0;
-  integrator1.Integrate(*grid, 0, N - 1, temp);
-  integrator2.Integrate(*grid, 0, N - 1, temp2);
+  RungeKutta<HartreeDeriv1,double> integrator1(H1);
+  RungeKutta<HartreeDeriv2,double> integrator2(H2);
+  temp(0) = 0.0;  temp2(0) = 0.0;
+  integrator1.Integrate(*grid, 0, N-1, temp);
+  integrator2.Integrate(*grid, 0, N-1, temp2);
 
-  for (int i = 0; i < N; i++)
-  {
-    double r   = (*grid)(i);
-    Hartree(i) = 4.0 * M_PI * (temp(i) / r + (temp2(N - 1) - temp2(i)));
+  for (int i=0; i<N; i++) {
+    double r = (*grid)(i);
+    Hartree(i) = 4.0*M_PI*(temp(i)/r + (temp2(N-1)-temp2(i)));
   }
 }
 
 void DFTAtom::UpdateExCorr()
 {
   int N = grid->NumPoints;
-  for (int i = 0; i < N; i++)
-  {
+  for (int i=0; i<N; i++) {
     double Vxcup, Vxcdown;
-    double upCharge   = 0.5 * ChargeDensity(i);
+    double upCharge = 0.5*ChargeDensity(i);
     double downCharge = upCharge;
     CPPExCorr(upCharge, downCharge, Vxcup, Vxcdown);
     //    FortranExCorr(upCharge, downCharge, Vxcup, Vxcdown);
@@ -108,24 +104,24 @@ void DFTAtom::UpdateExCorr()
 
 void DFTAtom::SetGrid(std::shared_ptr<Grid>& newgrid)
 {
-  grid  = newgrid;
+  grid = newgrid;
   int N = grid->NumPoints;
   temp.resize(N);
   temp2.resize(N);
   temp = 0.0;
   V.HXC.Init(grid, temp);
-  ChargeDensity.Init(grid, temp);
+  ChargeDensity.Init(grid,temp);
   Hartree.Init(grid, temp);
-  ExCorr.Init(grid, temp);
-  for (int i = 0; i < RadialWFs.size(); i++)
+  ExCorr.Init(grid,temp);
+  for (int i=0; i<RadialWFs.size(); i++)
     RadialWFs(i).SetGrid(grid);
 }
 
-void DFTAtom::SetBarePot(Potential* newPot)
+void DFTAtom::SetBarePot(Potential *newPot)
 {
-  BarePot   = newPot;
+  BarePot = newPot;
   V.BarePot = BarePot;
-  for (int i = 0; i < RadialWFs.size(); i++)
+  for (int i=0; i<RadialWFs.size(); i++)
     RadialWFs(i).SetPotential(&V);
 }
 
@@ -133,7 +129,7 @@ void DFTAtom::SetBarePot(Potential* newPot)
 //void
 //DFTAtom::SolveInit()
 //{
-//  int N = grid->NumPoints;
+//  int N = grid->NumPoints; 
 //  // Just rename temp and temp2 for clarity
 //  Array<double,1> &oldCharge = temp;
 //  Array<double,1> &newCharge = temp2;
@@ -142,7 +138,7 @@ void DFTAtom::SetBarePot(Potential* newPot)
 //  for (int i=0; i<N; i++)
 //    V.HXC(i) = 0.0;
 
-//  OldEnergies.resize(RadialWFs.size());
+//  OldEnergies.resize(RadialWFs.size());  
 //  // Now solve radial equations
 //  for (int i=0; i<RadialWFs.size(); i++) {
 //    RadialWFs(i).Solve();
@@ -161,7 +157,7 @@ void DFTAtom::SetBarePot(Potential* newPot)
 //double
 //DFTAtom::SolveIter()
 //{
-//  int N = grid->NumPoints;
+//  int N = grid->NumPoints; 
 //  // Just rename temp and temp2 for clarity
 //  Array<double,1> &oldCharge = temp;
 //  Array<double,1> &newCharge = temp2;
@@ -172,7 +168,7 @@ void DFTAtom::SetBarePot(Potential* newPot)
 //  UpdateExCorr();
 //  for (int i=0; i < grid->NumPoints; i++)
 //    V.HXC(i) = Hartree(i) + ExCorr(i);
-//
+//  
 //  double maxDiff = 0.0;
 //  for (int i=0; i<RadialWFs.size(); i++) {
 //    RadialWFs(i).Solve();
@@ -189,19 +185,18 @@ void DFTAtom::SetBarePot(Potential* newPot)
 
 void DFTAtom::Solve()
 {
-  int N = grid->NumPoints;
+  int N = grid->NumPoints; 
   // Just rename temp and temp2 for clarity
-  Array<double, 1>& oldCharge = temp;
-  Array<double, 1>& newCharge = temp2;
+  Array<double,1> &oldCharge = temp;
+  Array<double,1> &newCharge = temp2;
 
   // First, zero out screening
-  for (int i = 0; i < N; i++)
+  for (int i=0; i<N; i++)
     V.HXC(i) = 0.0;
 
-  Array<double, 1> oldEnergies(RadialWFs.size());
+  Array<double,1> oldEnergies(RadialWFs.size());  
   // Now solve radial equations
-  for (int i = 0; i < RadialWFs.size(); i++)
-  {
+  for (int i=0; i<RadialWFs.size(); i++) {
     RadialWFs(i).Solve();
     // fprintf (stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
     oldEnergies(i) = RadialWFs(i).Energy;
@@ -216,57 +211,56 @@ void DFTAtom::Solve()
 
   bool done = false;
 
-  while (!done)
-  {
-    for (int i = 0; i < N; i++)
-      ChargeDensity(i) = NewMix * (newCharge(i)) + (1.0 - NewMix) * oldCharge(i);
+  while (!done) {
+    for (int i=0; i<N; i++)
+      ChargeDensity(i) = NewMix*(newCharge(i)) + (1.0-NewMix)*oldCharge(i);
     UpdateHartree();
     UpdateExCorr();
-    for (int i = 0; i < grid->NumPoints; i++)
+    for (int i=0; i < grid->NumPoints; i++)
       V.HXC(i) = Hartree(i) + ExCorr(i);
 
     done = true;
-    for (int i = 0; i < RadialWFs.size(); i++)
-    {
+    for (int i=0; i<RadialWFs.size(); i++) {
       RadialWFs(i).Solve();
-      if (fabs(oldEnergies(i) - RadialWFs(i).Energy) > 1.0e-8)
-        done = false;
+      if (fabs(oldEnergies(i)-RadialWFs(i).Energy) > 1.0e-8)
+	done = false;
       oldEnergies(i) = RadialWFs(i).Energy;
     }
-    for (int i = 0; i < RadialWFs.size(); i++)
-      fprintf(stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
+    for (int i=0; i<RadialWFs.size(); i++)
+      fprintf (stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
     oldCharge = ChargeDensity.Data();
     UpdateChargeDensity();
     newCharge = ChargeDensity.Data();
   }
+  
+
 }
 
 
-void DFTAtom::Write(IOSectionClass& out)
+void DFTAtom::Write(IOSectionClass &out)
 {
-  out.WriteVar("Type", "DFT");
+  out.WriteVar ("Type", "DFT");
   out.NewSection("Grid");
   grid->Write(out);
   out.CloseSection();
 
-  for (int i = 0; i < RadialWFs.size(); i++)
-  {
+  for (int i=0; i<RadialWFs.size(); i++) {
     out.NewSection("RadialWF");
     RadialWFs(i).Write(out);
     out.CloseSection();
   }
 
-  out.WriteVar("ChargeDensity", ChargeDensity.Data());
-  out.WriteVar("Hartree", Hartree.Data());
-  out.WriteVar("ExCorr", ExCorr.Data());
+  out.WriteVar ("ChargeDensity", ChargeDensity.Data());
+  out.WriteVar ("Hartree", Hartree.Data());
+  out.WriteVar ("ExCorr", ExCorr.Data());
   out.NewSection("Potential");
   BarePot->Write(out);
   out.CloseSection();
-  out.WriteVar("NewMix", NewMix);
+  out.WriteVar ("NewMix", NewMix);
 }
 
 
-void DFTAtom::Read(IOSectionClass& in)
+void DFTAtom::Read(IOSectionClass &in) 
 {
   assert(in.OpenSection("Grid"));
   grid = ReadGrid(in);
@@ -280,22 +274,22 @@ void DFTAtom::Read(IOSectionClass& in)
   int numRadialWFs = in.CountSections("RadialWF");
   RadialWFs.resize(numRadialWFs);
   SetGrid(grid);
-  in.ReadVar("ChargeDensity", ChargeDensity.Data());
-  in.ReadVar("Hartree", Hartree.Data());
-  in.ReadVar("ExCorr", ExCorr.Data());
-  for (int i = 0; i < V.HXC.size(); i++)
-    V.HXC(i) = Hartree(i) + ExCorr(i);
+  in.ReadVar ("ChargeDensity", ChargeDensity.Data());
+  in.ReadVar ("Hartree", Hartree.Data());
+  in.ReadVar ("ExCorr", ExCorr.Data());
+  for (int i=0; i<V.HXC.size(); i++)
+    V.HXC(i) = Hartree(i)+ExCorr(i);
 
   double charge = 0.0;
-  for (int i = 0; i < numRadialWFs; i++)
-  {
-    RadialWFs(i).SetGrid(grid);
-    RadialWFs(i).SetPotential(&V);
-    assert(in.OpenSection("RadialWF", i));
+  for (int i=0; i<numRadialWFs; i++) {
+    RadialWFs(i).SetGrid (grid);
+    RadialWFs(i).SetPotential (&V);
+    assert (in.OpenSection("RadialWF", i));
     RadialWFs(i).Read(in);
     charge += RadialWFs(i).Occupancy;
     in.CloseSection();
   }
   V.Charge = charge;
-  assert(in.ReadVar("NewMix", NewMix));
+  assert (in.ReadVar("NewMix", NewMix));
 }
+

--- a/src/QMCTools/ppconvert/src/common/DFTAtom.h
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.h
@@ -48,7 +48,7 @@ public:
   double SolveIter();
   void Write(IOSectionClass& out) override;
   void Read(IOSectionClass& in) override;
-  void SetGrid(Grid* newGrid) override;
+  void SetGrid(std::shared_ptr<Grid>& newGrid) override;
   void SetBarePot(Potential* pot) override;
 
   inline double rho(double r) { return ChargeDensity(r); }

--- a/src/QMCTools/ppconvert/src/common/GeneralPot.cc
+++ b/src/QMCTools/ppconvert/src/common/GeneralPot.cc
@@ -8,25 +8,27 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-
-
+    
+    
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
 #include "GeneralPot.h"
 
-void GeneralPot::Read(IOSectionClass& in)
+void
+GeneralPot::Read(IOSectionClass &in)
 {
-  assert(in.OpenSection("Grid"));
-  PotGrid = ReadGrid(in);
+  assert (in.OpenSection("Grid"));
+  PotGrid = ReadGrid (in);
   in.CloseSection();
-  Array<double, 1> vdata;
-  assert(in.ReadVar("V", vdata));
-  assert(in.ReadVar("Z", Z));
-  PotSpline.Init(PotGrid, vdata);
+  Array<double,1> vdata;
+  assert (in.ReadVar("V", vdata));
+  assert (in.ReadVar("Z", Z));
+  PotSpline.Init (PotGrid, vdata);
 }
 
-void GeneralPot::Write(IOSectionClass& out)
+void
+GeneralPot::Write(IOSectionClass &out)
 {
   out.NewSection("Grid");
   PotGrid->Write(out);
@@ -36,29 +38,35 @@ void GeneralPot::Write(IOSectionClass& out)
   out.WriteVar("Type", "General");
 }
 
-double GeneralPot::V(double r)
+double
+GeneralPot::V(double r)
 {
   if (r < PotGrid->End)
     return PotSpline(r);
   else
-    return (-Z / r);
+    return (-Z/r);
 }
 
-double GeneralPot::dVdr(double r)
+double
+GeneralPot::dVdr (double r)
 {
   if (r < PotGrid->End)
     return PotSpline.Deriv(r);
   else
-    return Z / (r * r);
+    return Z/(r*r);
 }
 
-double GeneralPot::d2Vdr2(double r)
+double
+GeneralPot::d2Vdr2 (double r)
 {
   if (r < PotGrid->End)
     return PotSpline.Deriv2(r);
   else
-    return -2.0 * Z / (r * r * r);
+    return -2.0*Z/(r*r*r);
 }
 
 
-GeneralPot::GeneralPot() : PotGrid(NULL) {}
+GeneralPot::GeneralPot() : PotGrid(NULL)
+{
+
+}

--- a/src/QMCTools/ppconvert/src/common/GeneralPot.cc
+++ b/src/QMCTools/ppconvert/src/common/GeneralPot.cc
@@ -8,27 +8,25 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
 #include "GeneralPot.h"
 
-void
-GeneralPot::Read(IOSectionClass &in)
+void GeneralPot::Read(IOSectionClass& in)
 {
-  assert (in.OpenSection("Grid"));
-  PotGrid = ReadGrid (in);
+  assert(in.OpenSection("Grid"));
+  PotGrid = ReadGrid(in);
   in.CloseSection();
-  Array<double,1> vdata;
-  assert (in.ReadVar("V", vdata));
-  assert (in.ReadVar("Z", Z));
-  PotSpline.Init (PotGrid, vdata);
+  Array<double, 1> vdata;
+  assert(in.ReadVar("V", vdata));
+  assert(in.ReadVar("Z", Z));
+  PotSpline.Init(PotGrid, vdata);
 }
 
-void
-GeneralPot::Write(IOSectionClass &out)
+void GeneralPot::Write(IOSectionClass& out)
 {
   out.NewSection("Grid");
   PotGrid->Write(out);
@@ -38,41 +36,29 @@ GeneralPot::Write(IOSectionClass &out)
   out.WriteVar("Type", "General");
 }
 
-double
-GeneralPot::V(double r)
+double GeneralPot::V(double r)
 {
   if (r < PotGrid->End)
     return PotSpline(r);
   else
-    return (-Z/r);
+    return (-Z / r);
 }
 
-double
-GeneralPot::dVdr (double r)
+double GeneralPot::dVdr(double r)
 {
   if (r < PotGrid->End)
     return PotSpline.Deriv(r);
   else
-    return Z/(r*r);
+    return Z / (r * r);
 }
 
-double
-GeneralPot::d2Vdr2 (double r)
+double GeneralPot::d2Vdr2(double r)
 {
   if (r < PotGrid->End)
     return PotSpline.Deriv2(r);
   else
-    return -2.0*Z/(r*r*r);
+    return -2.0 * Z / (r * r * r);
 }
 
 
-GeneralPot::GeneralPot() : PotGrid(NULL)
-{
-
-}
-
-GeneralPot::~GeneralPot()
-{
-  if (PotGrid != NULL)
-    delete PotGrid;
-}
+GeneralPot::GeneralPot() : PotGrid(NULL) {}

--- a/src/QMCTools/ppconvert/src/common/GeneralPot.h
+++ b/src/QMCTools/ppconvert/src/common/GeneralPot.h
@@ -22,7 +22,7 @@
 class GeneralPot : public Potential
 {
 protected:
-  Grid* PotGrid;
+  std::shared_ptr<Grid> PotGrid;
   CubicSplineCommon PotSpline;
   double Z;
 
@@ -34,7 +34,7 @@ public:
   void Write(IOSectionClass& out) override;
   void Read(IOSectionClass& in) override;
   GeneralPot();
-  ~GeneralPot();
+  ~GeneralPot() = default;
 };
 
 #endif

--- a/src/QMCTools/ppconvert/src/common/Grid.h
+++ b/src/QMCTools/ppconvert/src/common/Grid.h
@@ -65,7 +65,7 @@ public:
   virtual int ReverseMap(double r)             = 0;
   virtual void Write(IOSectionClass& out)      = 0;
   virtual void Read(IOSectionClass& inSection) = 0;
-  virtual ~Grid(){}
+  virtual ~Grid() {}
 };
 
 
@@ -630,31 +630,31 @@ public:
 };
 
 
-inline Grid* ReadGrid(IOSectionClass& inSection)
+inline std::shared_ptr<Grid> ReadGrid(IOSectionClass& inSection)
 {
   std::string Type;
   assert(inSection.ReadVar("Type", Type));
 
-  Grid* newGrid;
+  std::shared_ptr<Grid> newGrid;
   if (Type == "Linear")
-    newGrid = new LinearGrid;
+    newGrid = std::make_shared<LinearGrid>();
   else if (Type == "General")
-    newGrid = new GeneralGrid;
+    newGrid = std::make_shared<GeneralGrid>();
   else if (Type == "Optimal")
-    newGrid = new OptimalGrid;
+    newGrid = std::make_shared<OptimalGrid>();
   else if (Type == "Optimal2")
-    newGrid = new OptimalGrid2;
+    newGrid = std::make_shared<OptimalGrid2>();
   else if (Type == "Log")
-    newGrid = new LogGrid;
+    newGrid = std::make_shared<LogGrid>();
   else if (Type == "Cluster")
-    newGrid = new ClusterGrid;
+    newGrid = std::make_shared<ClusterGrid>();
   else
   {
     std::cerr << "Unrecognized Grid type " << Type << "\n";
     exit(1);
   }
   newGrid->Read(inSection);
-  return (newGrid);
+  return newGrid;
 }
 
 

--- a/src/QMCTools/ppconvert/src/common/Grid.h
+++ b/src/QMCTools/ppconvert/src/common/Grid.h
@@ -65,7 +65,7 @@ public:
   virtual int ReverseMap(double r)             = 0;
   virtual void Write(IOSectionClass& out)      = 0;
   virtual void Read(IOSectionClass& inSection) = 0;
-  virtual ~Grid() {}
+  virtual ~Grid(){}
 };
 
 

--- a/src/QMCTools/ppconvert/src/common/NLPP.cc
+++ b/src/QMCTools/ppconvert/src/common/NLPP.cc
@@ -8,38 +8,30 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
 
 
 #include "NLPP.h"
 #include "GKIntegration.h"
 #include "MatrixOps.h"
 
-bool
-NLPPClass::IsNonlocal()
-{
-  return true;
-}
+bool NLPPClass::IsNonlocal() { return true; }
 
-void 
-ChannelPotential::Read(IOSectionClass &in, Grid *grid)
+void ChannelPotential::Read(IOSectionClass& in, std::shared_ptr<Grid>& grid)
 {
-  assert (in.ReadVar("l", l));
-  assert (in.ReadVar("n_principal", n_principal));
-  assert (in.ReadVar("Cutoff", rc));
+  assert(in.ReadVar("l", l));
+  assert(in.ReadVar("n_principal", n_principal));
+  assert(in.ReadVar("Cutoff", rc));
   R0 = 1.75 * rc;
-  assert (in.ReadVar("Occupation", Occupation));
-  assert (in.ReadVar("Eigenvalue", Eigenvalue));
-  Array<double,1> V_data, u_data;
-  assert (in.ReadVar("Vl", V_data));
-  assert (in.ReadVar("ul", u_data));
-  V.Init (grid, V_data);
-  u.Init (grid, u_data);
+  assert(in.ReadVar("Occupation", Occupation));
+  assert(in.ReadVar("Eigenvalue", Eigenvalue));
+  Array<double, 1> V_data, u_data;
+  assert(in.ReadVar("Vl", V_data));
+  assert(in.ReadVar("ul", u_data));
+  V.Init(grid, V_data);
+  u.Init(grid, u_data);
 }
 
-void
-ChannelPotential::Write(IOSectionClass &out)
+void ChannelPotential::Write(IOSectionClass& out)
 {
   out.WriteVar("l", l);
   out.WriteVar("n_principal", n_principal);
@@ -50,148 +42,153 @@ ChannelPotential::Write(IOSectionClass &out)
   out.WriteVar("ul", u.Data());
 }
 
-void
-NLPPClass::Read(IOSectionClass &in)
+void NLPPClass::Read(IOSectionClass& in)
 {
   assert(in.ReadVar("AtomicNumber", AtomicNumber));
   assert(in.ReadVar("LocalChannel", lLocal));
   assert(in.ReadVar("ValenceCharge", Zion));
   assert(in.ReadVar("Symbol", Symbol));
-  
+
   int numChannels = in.CountSections("lChannel");
   Vl.resize(numChannels);
-//   vector<Array<double,1> > vl(numChannels), ul(numChannels);
-//   vector<double> rc(numChannels);
-  assert (in.OpenSection("PotentialGrid"));
-  PotentialGrid = ReadGrid (in);
+  //   vector<Array<double,1> > vl(numChannels), ul(numChannels);
+  //   vector<double> rc(numChannels);
+  assert(in.OpenSection("PotentialGrid"));
+  PotentialGrid = ReadGrid(in);
   in.CloseSection(); // "PotentialGrid"
-  for (int i=0; i<numChannels; i++) {
-    assert (in.OpenSection("lChannel", i));
+  for (int i = 0; i < numChannels; i++)
+  {
+    assert(in.OpenSection("lChannel", i));
     int l;
-    assert (in.ReadVar("l", l));
-    if (l > numChannels) {
+    assert(in.ReadVar("l", l));
+    if (l > numChannels)
+    {
       std::cerr << "Skipped channels in NLPPClass read.\n";
       abort();
     }
     Vl[l].Read(in, PotentialGrid);
-    in.CloseSection (); // "lChannel"
+    in.CloseSection(); // "lChannel"
   }
-  for (int l=0; l<numChannels; l++) {
-    Array<double,1> deltav(PotentialGrid->NumPoints);
-    deltav = Vl[l].V.Data()- Vl[lLocal].V.Data();
-    Vl[l].DeltaV.Init (PotentialGrid, deltav);
+  for (int l = 0; l < numChannels; l++)
+  {
+    Array<double, 1> deltav(PotentialGrid->NumPoints);
+    deltav = Vl[l].V.Data() - Vl[lLocal].V.Data();
+    Vl[l].DeltaV.Init(PotentialGrid, deltav);
   }
 }
 
 
-void
-NLPPClass::Write(IOSectionClass &out)
+void NLPPClass::Write(IOSectionClass& out)
 {
-  out.WriteVar ("Type", "NLPP");
-  out.WriteVar ("LocalChannel", lLocal);
-  out.WriteVar ("AtomicNumber", AtomicNumber);
-  out.WriteVar ("Symbol", Symbol);
-  out.WriteVar ("ValenceCharge", Zion);
+  out.WriteVar("Type", "NLPP");
+  out.WriteVar("LocalChannel", lLocal);
+  out.WriteVar("AtomicNumber", AtomicNumber);
+  out.WriteVar("Symbol", Symbol);
+  out.WriteVar("ValenceCharge", Zion);
   out.NewSection("PotentialGrid");
   PotentialGrid->Write(out);
-  out.CloseSection();  // "PotentialGrid"
-  for (int i=0; i<Vl.size(); i++) {
+  out.CloseSection(); // "PotentialGrid"
+  for (int i = 0; i < Vl.size(); i++)
+  {
     out.NewSection("lChannel");
-    Vl[i].Write (out);
+    Vl[i].Write(out);
     out.CloseSection(); // "lChannel"
   }
 }
 
 
-
 // This function computes the Kleinman-Bylander projector for the
 // nonlocal channels of the pseudopotential.  It just calls
 // SetupProjector on each of the nonlocal channels.
-void
-NLPPClass::SetupProjectors(double G_max, double G_FFT)
+void NLPPClass::SetupProjectors(double G_max, double G_FFT)
 {
-  for (int i=0; i<Vl.size(); i++) 
-    if (Vl[i].l != lLocal) 
+  for (int i = 0; i < Vl.size(); i++)
+    if (Vl[i].l != lLocal)
       Vl[i].SetupProjector(G_max, G_FFT);
 
-  FILE *fout = fopen ("zeta_r.dat", "w");
-  for (double r=0.0; r<50.0; r+=0.001) {
-    fprintf (fout, "%12.16e ", r);
-      for (int l=0; l<Vl.size(); l++)
-	if (l != lLocal)
-	  fprintf (fout, "%12.16e ", Vl[l].zeta_r(r));
-    fprintf (fout, "\n");
+  FILE* fout = fopen("zeta_r.dat", "w");
+  for (double r = 0.0; r < 50.0; r += 0.001)
+  {
+    fprintf(fout, "%12.16e ", r);
+    for (int l = 0; l < Vl.size(); l++)
+      if (l != lLocal)
+        fprintf(fout, "%12.16e ", Vl[l].zeta_r(r));
+    fprintf(fout, "\n");
   }
-  fclose (fout);
-  
-  fout = fopen ("zeta_q.dat", "w");
-  for (double q=0.0; q<G_FFT; q+=0.001) {
-    fprintf (fout, "%12.16e ", q);
-      for (int l=0; l<Vl.size(); l++)
-	if (l != lLocal)
-	  fprintf (fout, "%12.16e ", Vl[l].zeta_q(q));
-    fprintf (fout, "\n");
-  }
-  fclose (fout);
+  fclose(fout);
 
-  fout = fopen ("chi_q.dat", "w");
-  for (double q=0.0; q<G_FFT; q+=0.001) {
-    fprintf (fout, "%12.16e ", q);
-      for (int l=0; l<Vl.size(); l++)
-	if (l != lLocal)
-	  fprintf (fout, "%12.16e ", Vl[l].chi_q(q));
-    fprintf (fout, "\n");
+  fout = fopen("zeta_q.dat", "w");
+  for (double q = 0.0; q < G_FFT; q += 0.001)
+  {
+    fprintf(fout, "%12.16e ", q);
+    for (int l = 0; l < Vl.size(); l++)
+      if (l != lLocal)
+        fprintf(fout, "%12.16e ", Vl[l].zeta_q(q));
+    fprintf(fout, "\n");
   }
-  fclose (fout);
+  fclose(fout);
 
-  fout = fopen ("chi_r.dat", "w");
-  for (double r=0.0; r<50.0; r+=0.001) {
-    fprintf (fout, "%12.16e ", r);
-      for (int l=0; l<Vl.size(); l++)
-	if (l != lLocal)
-	  fprintf (fout, "%12.16e ", Vl[l].chi_r(r));
-    fprintf (fout, "\n");
+  fout = fopen("chi_q.dat", "w");
+  for (double q = 0.0; q < G_FFT; q += 0.001)
+  {
+    fprintf(fout, "%12.16e ", q);
+    for (int l = 0; l < Vl.size(); l++)
+      if (l != lLocal)
+        fprintf(fout, "%12.16e ", Vl[l].chi_q(q));
+    fprintf(fout, "\n");
   }
-  fclose (fout);
+  fclose(fout);
 
+  fout = fopen("chi_r.dat", "w");
+  for (double r = 0.0; r < 50.0; r += 0.001)
+  {
+    fprintf(fout, "%12.16e ", r);
+    for (int l = 0; l < Vl.size(); l++)
+      if (l != lLocal)
+        fprintf(fout, "%12.16e ", Vl[l].chi_r(r));
+    fprintf(fout, "\n");
+  }
+  fclose(fout);
 }
 
 
 // A(q,q') = q^2 q'^2 \int_0^R0 j_l(qr) r^2 j_l(q'r) dr
-double
-ChannelPotential::A(double q, double qp)
+double ChannelPotential::A(double q, double qp)
 {
-  if (l == 0) {
-    if (q == qp) 
-      return -0.25*q*(-2.0*q*R0 + sin(2.0*q*R0));
+  if (l == 0)
+  {
+    if (q == qp)
+      return -0.25 * q * (-2.0 * q * R0 + sin(2.0 * q * R0));
     else
-      return -1.0/(q*q - qp*qp) * 
-	q * qp *(q*cos(q*R0)*sin(qp*R0) - qp*cos(qp*R0)*sin(q*R0));
+      return -1.0 / (q * q - qp * qp) * q * qp * (q * cos(q * R0) * sin(qp * R0) - qp * cos(qp * R0) * sin(q * R0));
   }
-  else if (l == 1){
-    if (q == qp) 
-      return (-2.0 + 2.0*q*q*R0*R0 + 2.0*cos(2.0*q*R0) + q*R0*sin(2.0*q*R0))/(4.0*R0);
+  else if (l == 1)
+  {
+    if (q == qp)
+      return (-2.0 + 2.0 * q * q * R0 * R0 + 2.0 * cos(2.0 * q * R0) + q * R0 * sin(2.0 * q * R0)) / (4.0 * R0);
     else
-      return q*qp/(q*q - qp*qp) *
-	(q*cos(qp*R0)*sin(q*R0) - qp*cos(q*R0)*sin(qp*R0))
-	- 1.0/R0 * sin(q*R0)*sin(qp*R0);
+      return q * qp / (q * q - qp * qp) * (q * cos(qp * R0) * sin(q * R0) - qp * cos(q * R0) * sin(qp * R0)) -
+          1.0 / R0 * sin(q * R0) * sin(qp * R0);
   }
-  else if (l == 2) {
+  else if (l == 2)
+  {
     if (qp == 0.0 || q == 0.0)
       return 0.0;
-    else if (q == qp) 
-      return 1.0/(4*q*q*R0*R0*R0)*
-	(-6.0 -6.0*q*q*R0*R0 + 2.0*q*q*q*q*R0*R0*R0*R0 + 
-	 (6.0-6.0*q*q*R0*R0)*cos(2.0*q*R0) + 
-	 q*R0*(12.0-q*q*R0*R0)*sin(2.0*q*R0));
-    else 
-      return 1.0/(q*qp*(q*q-qp*qp)*R0*R0*R0) *
-	(sin(q*R0)*(qp*R0*(-3.0*qp*qp + q*q*(3.0+qp*qp*R0*R0))*cos(qp*R0) +
-		    3.0*(qp*qp-q*q)*sin(qp*R0)) - q*R0*cos(q*R0) *
-	 (3.0*qp*(q*q - qp*qp)*R0*cos(qp*R0) + 
-	  (3.0*qp*qp + q*q*(-3.0 + qp*qp * R0*R0))*sin(qp*R0)));
+    else if (q == qp)
+      return 1.0 / (4 * q * q * R0 * R0 * R0) *
+          (-6.0 - 6.0 * q * q * R0 * R0 + 2.0 * q * q * q * q * R0 * R0 * R0 * R0 +
+           (6.0 - 6.0 * q * q * R0 * R0) * cos(2.0 * q * R0) + q * R0 * (12.0 - q * q * R0 * R0) * sin(2.0 * q * R0));
+    else
+      return 1.0 / (q * qp * (q * q - qp * qp) * R0 * R0 * R0) *
+          (sin(q * R0) *
+               (qp * R0 * (-3.0 * qp * qp + q * q * (3.0 + qp * qp * R0 * R0)) * cos(qp * R0) +
+                3.0 * (qp * qp - q * q) * sin(qp * R0)) -
+           q * R0 * cos(q * R0) *
+               (3.0 * qp * (q * q - qp * qp) * R0 * cos(qp * R0) +
+                (3.0 * qp * qp + q * q * (-3.0 + qp * qp * R0 * R0)) * sin(qp * R0)));
   }
-  else{
+  else
+  {
     assert(0);
     return std::numeric_limits<double>::quiet_NaN(); // sqrt(-1.0);
   }
@@ -213,86 +210,91 @@ ChannelPotential::A(double q, double qp)
 // DeltaV and u splines.  It then applies the methods of King-Smith et
 // al to filter out the high Fourier components, so that the
 // projector can be applied without error in real-space.
-void
-ChannelPotential::SetupProjector (double G_max, double G_FFT)
+void ChannelPotential::SetupProjector(double G_max, double G_FFT)
 {
-  Grid &grid = *u.grid;
+  Grid& grid = *u.grid;
   // First, compute zeta_r, normalization, and E_KB
   Job = NORM;
   GKIntegration<ChannelPotential> integrator(*this);
-  double norm = integrator.Integrate(0.0, grid.End, 1.0e-12);
-  ProjectorNorm = 1.0/sqrt(norm);
-  Job = EKB;
-  E_KB = norm/integrator.Integrate(0.0, grid.End, 1.0e-12);
-  std::cerr << "l = " << l << "  Norm is " << norm 
-       << "  E_KB is " << E_KB << "  R0 = " << R0 << std::endl;
-  
+  double norm   = integrator.Integrate(0.0, grid.End, 1.0e-12);
+  ProjectorNorm = 1.0 / sqrt(norm);
+  Job           = EKB;
+  E_KB          = norm / integrator.Integrate(0.0, grid.End, 1.0e-12);
+  std::cerr << "l = " << l << "  Norm is " << norm << "  E_KB is " << E_KB << "  R0 = " << R0 << std::endl;
+
   // Compute zeta(r)
-  Array<double,1> zeta(grid.NumPoints);
-  zeta(0) = ProjectorNorm * DeltaV(0)*u(1.0e-8)*1.0e8;
-  for (int i=1; i<grid.NumPoints; i++) 
-    zeta(i) = ProjectorNorm * DeltaV(i)*u(i)/grid(i);
-  zeta_r.Init (&grid, zeta);
+  Array<double, 1> zeta(grid.NumPoints);
+  zeta(0) = ProjectorNorm * DeltaV(0) * u(1.0e-8) * 1.0e8;
+  for (int i = 1; i < grid.NumPoints; i++)
+    zeta(i) = ProjectorNorm * DeltaV(i) * u(i) / grid(i);
+  zeta_r.Init(u.grid, zeta);
 
   // Compute zeta(q)
   Job = ZETA_Q;
-  qGrid.Init (0.0, G_FFT, 1000);
+  qGrid.Init(0.0, G_FFT, 1000);
   zeta.resize(qGrid.NumPoints);
-  for (int i=0; i<qGrid.NumPoints; i++) {
+  for (int i = 0; i < qGrid.NumPoints; i++)
+  {
     qCurrent = qGrid(i);
-    zeta(i) = integrator.Integrate(0.0, grid.End, 1.0e-12);
+    zeta(i)  = integrator.Integrate(0.0, grid.End, 1.0e-12);
   }
-  zeta_q.Init (&qGrid, zeta);
+  std::shared_ptr<Grid> qGridSharedPtr(&qGrid);
+  zeta_q.Init(qGridSharedPtr, zeta);
 
 
   double gamma = G_FFT - G_max;
   // Zero out zeta_q above gamma;
-  Array<double,1> chi_q_data(qGrid.NumPoints);
-  for (int i=0; i<qGrid.NumPoints; i++) 
+  Array<double, 1> chi_q_data(qGrid.NumPoints);
+  for (int i = 0; i < qGrid.NumPoints; i++)
     chi_q_data(i) = (qGrid(i) >= gamma) ? 0.0 : zeta_q(i);
-  chi_q.Init  (&qGrid, chi_q_data);  
+
+  chi_q.Init(qGridSharedPtr, chi_q_data);
 
   // Now for the magic:  We adjust chi_q between G_max and gamma so
   // that the real-space oscillations outside R0 are damped out
   // See King-Smith et al, PRB 44 13063
   // Find index of gamma
   int gammaIndex = qGrid.ReverseMap(gamma);
-  int G_maxIndex  = qGrid.ReverseMap(G_max)+1;
-  double delta = qGrid(1)-qGrid(0);
-  int nb = gammaIndex - G_maxIndex;
-  Array<double,1> b(nb), x(nb);
+  int G_maxIndex = qGrid.ReverseMap(G_max) + 1;
+  double delta   = qGrid(1) - qGrid(0);
+  int nb         = gammaIndex - G_maxIndex;
+  Array<double, 1> b(nb), x(nb);
   // First, create the b vector
   b = 0.0;
-  for (int i=0; i<nb; i++) {
-    double q = qGrid(G_maxIndex+i);
-    for (int j=0; j<G_maxIndex; j++) {
-      double qp = qGrid (j);
-      b(i) -= delta * A(q, qp)*zeta_q(j);
+  for (int i = 0; i < nb; i++)
+  {
+    double q = qGrid(G_maxIndex + i);
+    for (int j = 0; j < G_maxIndex; j++)
+    {
+      double qp = qGrid(j);
+      b(i) -= delta * A(q, qp) * zeta_q(j);
     }
   }
   // Now, create the M matrix
-  Array<double,2> M(nb, nb);
-  for (int i=0; i<nb; i++) {
-    double q = qGrid(G_maxIndex+i);
-    for (int j=0; j<nb; j++) {
-      double qp = qGrid(G_maxIndex+j);
-      M(i,j) = delta*A(q, qp);
+  Array<double, 2> M(nb, nb);
+  for (int i = 0; i < nb; i++)
+  {
+    double q = qGrid(G_maxIndex + i);
+    for (int j = 0; j < nb; j++)
+    {
+      double qp = qGrid(G_maxIndex + j);
+      M(i, j)   = delta * A(q, qp);
     }
-    M(i,i) -= 0.5*M_PI*q*q;
+    M(i, i) -= 0.5 * M_PI * q * q;
   }
-//   if (l==2) {
-//     FILE *fout = fopen ("M.dat", "w");
-//     for (int i=0; i<nb; i++) {
-//       for (int j=0; j<nb; j++) 
-// 	fprintf (fout, "%24.16e ", M(i,j));
-//       fprintf (fout, "\n");
-//     }
-//     fclose (fout);
-//     fout = fopen ("b.dat", "w");
-//     for (int i=0; i<nb; i++)
-//       fprintf (fout, "%24.16e\n", b(i));
-//     fclose (fout);
-//   }
+  //   if (l==2) {
+  //     FILE *fout = fopen ("M.dat", "w");
+  //     for (int i=0; i<nb; i++) {
+  //       for (int j=0; j<nb; j++)
+  // 	fprintf (fout, "%24.16e ", M(i,j));
+  //       fprintf (fout, "\n");
+  //     }
+  //     fclose (fout);
+  //     fout = fopen ("b.dat", "w");
+  //     for (int i=0; i<nb; i++)
+  //       fprintf (fout, "%24.16e\n", b(i));
+  //     fclose (fout);
+  //   }
   // Now solve Mx = b
   Array<int, 1> perm({nb}, int{0});
 
@@ -300,36 +302,35 @@ ChannelPotential::SetupProjector (double G_max, double G_FFT)
   assert(size(LU) == size(M)); // check it is invertible
   x = lup::solve(LU, perm, b);
 
-  for (int i=0; i<nb; i++) 
-    chi_q(G_maxIndex+i) = x(i);
-  chi_q(G_maxIndex+nb) = 0.0;
-  
-//   FILE *fout = fopen("chicheck.dat","w");
-//   for (double q=0.0; q<qGrid.End; q+=0.001)
-//     fprintf (fout, "%24.16e %24.16e\n", q, chi_q(q));
-//   fclose (fout);
+  for (int i = 0; i < nb; i++)
+    chi_q(G_maxIndex + i) = x(i);
+  chi_q(G_maxIndex + nb) = 0.0;
+
+  //   FILE *fout = fopen("chicheck.dat","w");
+  //   for (double q=0.0; q<qGrid.End; q+=0.001)
+  //     fprintf (fout, "%24.16e %24.16e\n", q, chi_q(q));
+  //   fclose (fout);
 
   // Now transform back to real-space, computing chi(r)
   Job = CHI_R;
-  Array<double,1> chi_r_data(grid.NumPoints);
-  for (int i=1; i<grid.NumPoints; i++) {
-    rCurrent = grid(i);
+  Array<double, 1> chi_r_data(grid.NumPoints);
+  for (int i = 1; i < grid.NumPoints; i++)
+  {
+    rCurrent      = grid(i);
     chi_r_data(i) = integrator.Integrate(0.0, gamma, 1.0e-10);
   }
-  chi_r.Init (&grid, chi_r_data);
+  chi_r.Init(u.grid, chi_r_data);
 
   // Finally, check to see if chi_r is small outside R0
-  Job = CHECK_CHI_R;
+  Job          = CHECK_CHI_R;
   double norm2 = integrator.Integrate(0.0, grid.End, 1.0e-8);
-  double error = integrator.Integrate( R0, grid.End, 1.0e-8);
+  double error = integrator.Integrate(R0, grid.End, 1.0e-8);
   if (error > 1.0e-16)
-    std::cerr << "Fractional error in real-space projection = "
-	 << (error / norm2) << std::endl;
+    std::cerr << "Fractional error in real-space projection = " << (error / norm2) << std::endl;
 }
 
 
-double
-NLPPClass::V(int l, double r)
+double NLPPClass::V(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V(r);
@@ -337,8 +338,7 @@ NLPPClass::V(int l, double r)
     return Vl[lLocal].V(r);
 }
 
-double
-NLPPClass::dVdr(int l, double r)
+double NLPPClass::dVdr(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V.Deriv(r);
@@ -346,8 +346,7 @@ NLPPClass::dVdr(int l, double r)
     return Vl[lLocal].V.Deriv(r);
 }
 
-double
-NLPPClass::d2Vdr2(int l, double r)
+double NLPPClass::d2Vdr2(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V.Deriv2(r);
@@ -355,20 +354,8 @@ NLPPClass::d2Vdr2(int l, double r)
     return Vl[lLocal].V.Deriv2(r);
 }
 
-double
-NLPPClass::V(double r)
-{
-  return Vl[lLocal].V(r);
-}
+double NLPPClass::V(double r) { return Vl[lLocal].V(r); }
 
-double
-NLPPClass::dVdr(double r)
-{
-  return Vl[lLocal].V.Deriv(r);
-}
+double NLPPClass::dVdr(double r) { return Vl[lLocal].V.Deriv(r); }
 
-double
-NLPPClass::d2Vdr2(double r)
-{
-  return Vl[lLocal].V.Deriv2(r);
-}
+double NLPPClass::d2Vdr2(double r) { return Vl[lLocal].V.Deriv2(r); }

--- a/src/QMCTools/ppconvert/src/common/NLPP.cc
+++ b/src/QMCTools/ppconvert/src/common/NLPP.cc
@@ -8,30 +8,38 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
+    
+    
 
 
 #include "NLPP.h"
 #include "GKIntegration.h"
 #include "MatrixOps.h"
 
-bool NLPPClass::IsNonlocal() { return true; }
-
-void ChannelPotential::Read(IOSectionClass& in, std::shared_ptr<Grid>& grid)
+bool
+NLPPClass::IsNonlocal()
 {
-  assert(in.ReadVar("l", l));
-  assert(in.ReadVar("n_principal", n_principal));
-  assert(in.ReadVar("Cutoff", rc));
-  R0 = 1.75 * rc;
-  assert(in.ReadVar("Occupation", Occupation));
-  assert(in.ReadVar("Eigenvalue", Eigenvalue));
-  Array<double, 1> V_data, u_data;
-  assert(in.ReadVar("Vl", V_data));
-  assert(in.ReadVar("ul", u_data));
-  V.Init(grid, V_data);
-  u.Init(grid, u_data);
+  return true;
 }
 
-void ChannelPotential::Write(IOSectionClass& out)
+void 
+ChannelPotential::Read(IOSectionClass &in, std::shared_ptr<Grid>& grid)
+{
+  assert (in.ReadVar("l", l));
+  assert (in.ReadVar("n_principal", n_principal));
+  assert (in.ReadVar("Cutoff", rc));
+  R0 = 1.75 * rc;
+  assert (in.ReadVar("Occupation", Occupation));
+  assert (in.ReadVar("Eigenvalue", Eigenvalue));
+  Array<double,1> V_data, u_data;
+  assert (in.ReadVar("Vl", V_data));
+  assert (in.ReadVar("ul", u_data));
+  V.Init (grid, V_data);
+  u.Init (grid, u_data);
+}
+
+void
+ChannelPotential::Write(IOSectionClass &out)
 {
   out.WriteVar("l", l);
   out.WriteVar("n_principal", n_principal);
@@ -42,153 +50,148 @@ void ChannelPotential::Write(IOSectionClass& out)
   out.WriteVar("ul", u.Data());
 }
 
-void NLPPClass::Read(IOSectionClass& in)
+void
+NLPPClass::Read(IOSectionClass &in)
 {
   assert(in.ReadVar("AtomicNumber", AtomicNumber));
   assert(in.ReadVar("LocalChannel", lLocal));
   assert(in.ReadVar("ValenceCharge", Zion));
   assert(in.ReadVar("Symbol", Symbol));
-
+  
   int numChannels = in.CountSections("lChannel");
   Vl.resize(numChannels);
-  //   vector<Array<double,1> > vl(numChannels), ul(numChannels);
-  //   vector<double> rc(numChannels);
-  assert(in.OpenSection("PotentialGrid"));
-  PotentialGrid = ReadGrid(in);
+//   vector<Array<double,1> > vl(numChannels), ul(numChannels);
+//   vector<double> rc(numChannels);
+  assert (in.OpenSection("PotentialGrid"));
+  PotentialGrid = ReadGrid (in);
   in.CloseSection(); // "PotentialGrid"
-  for (int i = 0; i < numChannels; i++)
-  {
-    assert(in.OpenSection("lChannel", i));
+  for (int i=0; i<numChannels; i++) {
+    assert (in.OpenSection("lChannel", i));
     int l;
-    assert(in.ReadVar("l", l));
-    if (l > numChannels)
-    {
+    assert (in.ReadVar("l", l));
+    if (l > numChannels) {
       std::cerr << "Skipped channels in NLPPClass read.\n";
       abort();
     }
     Vl[l].Read(in, PotentialGrid);
-    in.CloseSection(); // "lChannel"
+    in.CloseSection (); // "lChannel"
   }
-  for (int l = 0; l < numChannels; l++)
-  {
-    Array<double, 1> deltav(PotentialGrid->NumPoints);
-    deltav = Vl[l].V.Data() - Vl[lLocal].V.Data();
-    Vl[l].DeltaV.Init(PotentialGrid, deltav);
+  for (int l=0; l<numChannels; l++) {
+    Array<double,1> deltav(PotentialGrid->NumPoints);
+    deltav = Vl[l].V.Data()- Vl[lLocal].V.Data();
+    Vl[l].DeltaV.Init (PotentialGrid, deltav);
   }
 }
 
 
-void NLPPClass::Write(IOSectionClass& out)
+void
+NLPPClass::Write(IOSectionClass &out)
 {
-  out.WriteVar("Type", "NLPP");
-  out.WriteVar("LocalChannel", lLocal);
-  out.WriteVar("AtomicNumber", AtomicNumber);
-  out.WriteVar("Symbol", Symbol);
-  out.WriteVar("ValenceCharge", Zion);
+  out.WriteVar ("Type", "NLPP");
+  out.WriteVar ("LocalChannel", lLocal);
+  out.WriteVar ("AtomicNumber", AtomicNumber);
+  out.WriteVar ("Symbol", Symbol);
+  out.WriteVar ("ValenceCharge", Zion);
   out.NewSection("PotentialGrid");
   PotentialGrid->Write(out);
-  out.CloseSection(); // "PotentialGrid"
-  for (int i = 0; i < Vl.size(); i++)
-  {
+  out.CloseSection();  // "PotentialGrid"
+  for (int i=0; i<Vl.size(); i++) {
     out.NewSection("lChannel");
-    Vl[i].Write(out);
+    Vl[i].Write (out);
     out.CloseSection(); // "lChannel"
   }
 }
 
 
+
 // This function computes the Kleinman-Bylander projector for the
 // nonlocal channels of the pseudopotential.  It just calls
 // SetupProjector on each of the nonlocal channels.
-void NLPPClass::SetupProjectors(double G_max, double G_FFT)
+void
+NLPPClass::SetupProjectors(double G_max, double G_FFT)
 {
-  for (int i = 0; i < Vl.size(); i++)
-    if (Vl[i].l != lLocal)
+  for (int i=0; i<Vl.size(); i++) 
+    if (Vl[i].l != lLocal) 
       Vl[i].SetupProjector(G_max, G_FFT);
 
-  FILE* fout = fopen("zeta_r.dat", "w");
-  for (double r = 0.0; r < 50.0; r += 0.001)
-  {
-    fprintf(fout, "%12.16e ", r);
-    for (int l = 0; l < Vl.size(); l++)
-      if (l != lLocal)
-        fprintf(fout, "%12.16e ", Vl[l].zeta_r(r));
-    fprintf(fout, "\n");
+  FILE *fout = fopen ("zeta_r.dat", "w");
+  for (double r=0.0; r<50.0; r+=0.001) {
+    fprintf (fout, "%12.16e ", r);
+      for (int l=0; l<Vl.size(); l++)
+	if (l != lLocal)
+	  fprintf (fout, "%12.16e ", Vl[l].zeta_r(r));
+    fprintf (fout, "\n");
   }
-  fclose(fout);
+  fclose (fout);
+  
+  fout = fopen ("zeta_q.dat", "w");
+  for (double q=0.0; q<G_FFT; q+=0.001) {
+    fprintf (fout, "%12.16e ", q);
+      for (int l=0; l<Vl.size(); l++)
+	if (l != lLocal)
+	  fprintf (fout, "%12.16e ", Vl[l].zeta_q(q));
+    fprintf (fout, "\n");
+  }
+  fclose (fout);
 
-  fout = fopen("zeta_q.dat", "w");
-  for (double q = 0.0; q < G_FFT; q += 0.001)
-  {
-    fprintf(fout, "%12.16e ", q);
-    for (int l = 0; l < Vl.size(); l++)
-      if (l != lLocal)
-        fprintf(fout, "%12.16e ", Vl[l].zeta_q(q));
-    fprintf(fout, "\n");
+  fout = fopen ("chi_q.dat", "w");
+  for (double q=0.0; q<G_FFT; q+=0.001) {
+    fprintf (fout, "%12.16e ", q);
+      for (int l=0; l<Vl.size(); l++)
+	if (l != lLocal)
+	  fprintf (fout, "%12.16e ", Vl[l].chi_q(q));
+    fprintf (fout, "\n");
   }
-  fclose(fout);
+  fclose (fout);
 
-  fout = fopen("chi_q.dat", "w");
-  for (double q = 0.0; q < G_FFT; q += 0.001)
-  {
-    fprintf(fout, "%12.16e ", q);
-    for (int l = 0; l < Vl.size(); l++)
-      if (l != lLocal)
-        fprintf(fout, "%12.16e ", Vl[l].chi_q(q));
-    fprintf(fout, "\n");
+  fout = fopen ("chi_r.dat", "w");
+  for (double r=0.0; r<50.0; r+=0.001) {
+    fprintf (fout, "%12.16e ", r);
+      for (int l=0; l<Vl.size(); l++)
+	if (l != lLocal)
+	  fprintf (fout, "%12.16e ", Vl[l].chi_r(r));
+    fprintf (fout, "\n");
   }
-  fclose(fout);
+  fclose (fout);
 
-  fout = fopen("chi_r.dat", "w");
-  for (double r = 0.0; r < 50.0; r += 0.001)
-  {
-    fprintf(fout, "%12.16e ", r);
-    for (int l = 0; l < Vl.size(); l++)
-      if (l != lLocal)
-        fprintf(fout, "%12.16e ", Vl[l].chi_r(r));
-    fprintf(fout, "\n");
-  }
-  fclose(fout);
 }
 
 
 // A(q,q') = q^2 q'^2 \int_0^R0 j_l(qr) r^2 j_l(q'r) dr
-double ChannelPotential::A(double q, double qp)
+double
+ChannelPotential::A(double q, double qp)
 {
-  if (l == 0)
-  {
-    if (q == qp)
-      return -0.25 * q * (-2.0 * q * R0 + sin(2.0 * q * R0));
+  if (l == 0) {
+    if (q == qp) 
+      return -0.25*q*(-2.0*q*R0 + sin(2.0*q*R0));
     else
-      return -1.0 / (q * q - qp * qp) * q * qp * (q * cos(q * R0) * sin(qp * R0) - qp * cos(qp * R0) * sin(q * R0));
+      return -1.0/(q*q - qp*qp) * 
+	q * qp *(q*cos(q*R0)*sin(qp*R0) - qp*cos(qp*R0)*sin(q*R0));
   }
-  else if (l == 1)
-  {
-    if (q == qp)
-      return (-2.0 + 2.0 * q * q * R0 * R0 + 2.0 * cos(2.0 * q * R0) + q * R0 * sin(2.0 * q * R0)) / (4.0 * R0);
+  else if (l == 1){
+    if (q == qp) 
+      return (-2.0 + 2.0*q*q*R0*R0 + 2.0*cos(2.0*q*R0) + q*R0*sin(2.0*q*R0))/(4.0*R0);
     else
-      return q * qp / (q * q - qp * qp) * (q * cos(qp * R0) * sin(q * R0) - qp * cos(q * R0) * sin(qp * R0)) -
-          1.0 / R0 * sin(q * R0) * sin(qp * R0);
+      return q*qp/(q*q - qp*qp) *
+	(q*cos(qp*R0)*sin(q*R0) - qp*cos(q*R0)*sin(qp*R0))
+	- 1.0/R0 * sin(q*R0)*sin(qp*R0);
   }
-  else if (l == 2)
-  {
+  else if (l == 2) {
     if (qp == 0.0 || q == 0.0)
       return 0.0;
-    else if (q == qp)
-      return 1.0 / (4 * q * q * R0 * R0 * R0) *
-          (-6.0 - 6.0 * q * q * R0 * R0 + 2.0 * q * q * q * q * R0 * R0 * R0 * R0 +
-           (6.0 - 6.0 * q * q * R0 * R0) * cos(2.0 * q * R0) + q * R0 * (12.0 - q * q * R0 * R0) * sin(2.0 * q * R0));
-    else
-      return 1.0 / (q * qp * (q * q - qp * qp) * R0 * R0 * R0) *
-          (sin(q * R0) *
-               (qp * R0 * (-3.0 * qp * qp + q * q * (3.0 + qp * qp * R0 * R0)) * cos(qp * R0) +
-                3.0 * (qp * qp - q * q) * sin(qp * R0)) -
-           q * R0 * cos(q * R0) *
-               (3.0 * qp * (q * q - qp * qp) * R0 * cos(qp * R0) +
-                (3.0 * qp * qp + q * q * (-3.0 + qp * qp * R0 * R0)) * sin(qp * R0)));
+    else if (q == qp) 
+      return 1.0/(4*q*q*R0*R0*R0)*
+	(-6.0 -6.0*q*q*R0*R0 + 2.0*q*q*q*q*R0*R0*R0*R0 + 
+	 (6.0-6.0*q*q*R0*R0)*cos(2.0*q*R0) + 
+	 q*R0*(12.0-q*q*R0*R0)*sin(2.0*q*R0));
+    else 
+      return 1.0/(q*qp*(q*q-qp*qp)*R0*R0*R0) *
+	(sin(q*R0)*(qp*R0*(-3.0*qp*qp + q*q*(3.0+qp*qp*R0*R0))*cos(qp*R0) +
+		    3.0*(qp*qp-q*q)*sin(qp*R0)) - q*R0*cos(q*R0) *
+	 (3.0*qp*(q*q - qp*qp)*R0*cos(qp*R0) + 
+	  (3.0*qp*qp + q*q*(-3.0 + qp*qp * R0*R0))*sin(qp*R0)));
   }
-  else
-  {
+  else{
     assert(0);
     return std::numeric_limits<double>::quiet_NaN(); // sqrt(-1.0);
   }
@@ -210,91 +213,87 @@ double ChannelPotential::A(double q, double qp)
 // DeltaV and u splines.  It then applies the methods of King-Smith et
 // al to filter out the high Fourier components, so that the
 // projector can be applied without error in real-space.
-void ChannelPotential::SetupProjector(double G_max, double G_FFT)
+void
+ChannelPotential::SetupProjector (double G_max, double G_FFT)
 {
-  Grid& grid = *u.grid;
+  Grid &grid = *u.grid;
   // First, compute zeta_r, normalization, and E_KB
   Job = NORM;
   GKIntegration<ChannelPotential> integrator(*this);
-  double norm   = integrator.Integrate(0.0, grid.End, 1.0e-12);
-  ProjectorNorm = 1.0 / sqrt(norm);
-  Job           = EKB;
-  E_KB          = norm / integrator.Integrate(0.0, grid.End, 1.0e-12);
-  std::cerr << "l = " << l << "  Norm is " << norm << "  E_KB is " << E_KB << "  R0 = " << R0 << std::endl;
-
+  double norm = integrator.Integrate(0.0, grid.End, 1.0e-12);
+  ProjectorNorm = 1.0/sqrt(norm);
+  Job = EKB;
+  E_KB = norm/integrator.Integrate(0.0, grid.End, 1.0e-12);
+  std::cerr << "l = " << l << "  Norm is " << norm 
+       << "  E_KB is " << E_KB << "  R0 = " << R0 << std::endl;
+  
   // Compute zeta(r)
-  Array<double, 1> zeta(grid.NumPoints);
-  zeta(0) = ProjectorNorm * DeltaV(0) * u(1.0e-8) * 1.0e8;
-  for (int i = 1; i < grid.NumPoints; i++)
-    zeta(i) = ProjectorNorm * DeltaV(i) * u(i) / grid(i);
-  zeta_r.Init(u.grid, zeta);
+  Array<double,1> zeta(grid.NumPoints);
+  zeta(0) = ProjectorNorm * DeltaV(0)*u(1.0e-8)*1.0e8;
+  for (int i=1; i<grid.NumPoints; i++) 
+    zeta(i) = ProjectorNorm * DeltaV(i)*u(i)/grid(i);
+  zeta_r.Init (u.grid, zeta);
 
   // Compute zeta(q)
   Job = ZETA_Q;
-  qGrid.Init(0.0, G_FFT, 1000);
+  qGrid.Init (0.0, G_FFT, 1000);
   zeta.resize(qGrid.NumPoints);
-  for (int i = 0; i < qGrid.NumPoints; i++)
-  {
+  for (int i=0; i<qGrid.NumPoints; i++) {
     qCurrent = qGrid(i);
-    zeta(i)  = integrator.Integrate(0.0, grid.End, 1.0e-12);
+    zeta(i) = integrator.Integrate(0.0, grid.End, 1.0e-12);
   }
   std::shared_ptr<Grid> qGridSharedPtr(&qGrid);
-  zeta_q.Init(qGridSharedPtr, zeta);
+  zeta_q.Init (qGridSharedPtr, zeta);
 
 
   double gamma = G_FFT - G_max;
   // Zero out zeta_q above gamma;
-  Array<double, 1> chi_q_data(qGrid.NumPoints);
-  for (int i = 0; i < qGrid.NumPoints; i++)
+  Array<double,1> chi_q_data(qGrid.NumPoints);
+  for (int i=0; i<qGrid.NumPoints; i++) 
     chi_q_data(i) = (qGrid(i) >= gamma) ? 0.0 : zeta_q(i);
-
-  chi_q.Init(qGridSharedPtr, chi_q_data);
+  chi_q.Init  (qGridSharedPtr, chi_q_data);
 
   // Now for the magic:  We adjust chi_q between G_max and gamma so
   // that the real-space oscillations outside R0 are damped out
   // See King-Smith et al, PRB 44 13063
   // Find index of gamma
   int gammaIndex = qGrid.ReverseMap(gamma);
-  int G_maxIndex = qGrid.ReverseMap(G_max) + 1;
-  double delta   = qGrid(1) - qGrid(0);
-  int nb         = gammaIndex - G_maxIndex;
-  Array<double, 1> b(nb), x(nb);
+  int G_maxIndex  = qGrid.ReverseMap(G_max)+1;
+  double delta = qGrid(1)-qGrid(0);
+  int nb = gammaIndex - G_maxIndex;
+  Array<double,1> b(nb), x(nb);
   // First, create the b vector
   b = 0.0;
-  for (int i = 0; i < nb; i++)
-  {
-    double q = qGrid(G_maxIndex + i);
-    for (int j = 0; j < G_maxIndex; j++)
-    {
-      double qp = qGrid(j);
-      b(i) -= delta * A(q, qp) * zeta_q(j);
+  for (int i=0; i<nb; i++) {
+    double q = qGrid(G_maxIndex+i);
+    for (int j=0; j<G_maxIndex; j++) {
+      double qp = qGrid (j);
+      b(i) -= delta * A(q, qp)*zeta_q(j);
     }
   }
   // Now, create the M matrix
-  Array<double, 2> M(nb, nb);
-  for (int i = 0; i < nb; i++)
-  {
-    double q = qGrid(G_maxIndex + i);
-    for (int j = 0; j < nb; j++)
-    {
-      double qp = qGrid(G_maxIndex + j);
-      M(i, j)   = delta * A(q, qp);
+  Array<double,2> M(nb, nb);
+  for (int i=0; i<nb; i++) {
+    double q = qGrid(G_maxIndex+i);
+    for (int j=0; j<nb; j++) {
+      double qp = qGrid(G_maxIndex+j);
+      M(i,j) = delta*A(q, qp);
     }
-    M(i, i) -= 0.5 * M_PI * q * q;
+    M(i,i) -= 0.5*M_PI*q*q;
   }
-  //   if (l==2) {
-  //     FILE *fout = fopen ("M.dat", "w");
-  //     for (int i=0; i<nb; i++) {
-  //       for (int j=0; j<nb; j++)
-  // 	fprintf (fout, "%24.16e ", M(i,j));
-  //       fprintf (fout, "\n");
-  //     }
-  //     fclose (fout);
-  //     fout = fopen ("b.dat", "w");
-  //     for (int i=0; i<nb; i++)
-  //       fprintf (fout, "%24.16e\n", b(i));
-  //     fclose (fout);
-  //   }
+//   if (l==2) {
+//     FILE *fout = fopen ("M.dat", "w");
+//     for (int i=0; i<nb; i++) {
+//       for (int j=0; j<nb; j++) 
+// 	fprintf (fout, "%24.16e ", M(i,j));
+//       fprintf (fout, "\n");
+//     }
+//     fclose (fout);
+//     fout = fopen ("b.dat", "w");
+//     for (int i=0; i<nb; i++)
+//       fprintf (fout, "%24.16e\n", b(i));
+//     fclose (fout);
+//   }
   // Now solve Mx = b
   Array<int, 1> perm({nb}, int{0});
 
@@ -302,35 +301,36 @@ void ChannelPotential::SetupProjector(double G_max, double G_FFT)
   assert(size(LU) == size(M)); // check it is invertible
   x = lup::solve(LU, perm, b);
 
-  for (int i = 0; i < nb; i++)
-    chi_q(G_maxIndex + i) = x(i);
-  chi_q(G_maxIndex + nb) = 0.0;
-
-  //   FILE *fout = fopen("chicheck.dat","w");
-  //   for (double q=0.0; q<qGrid.End; q+=0.001)
-  //     fprintf (fout, "%24.16e %24.16e\n", q, chi_q(q));
-  //   fclose (fout);
+  for (int i=0; i<nb; i++) 
+    chi_q(G_maxIndex+i) = x(i);
+  chi_q(G_maxIndex+nb) = 0.0;
+  
+//   FILE *fout = fopen("chicheck.dat","w");
+//   for (double q=0.0; q<qGrid.End; q+=0.001)
+//     fprintf (fout, "%24.16e %24.16e\n", q, chi_q(q));
+//   fclose (fout);
 
   // Now transform back to real-space, computing chi(r)
   Job = CHI_R;
-  Array<double, 1> chi_r_data(grid.NumPoints);
-  for (int i = 1; i < grid.NumPoints; i++)
-  {
-    rCurrent      = grid(i);
+  Array<double,1> chi_r_data(grid.NumPoints);
+  for (int i=1; i<grid.NumPoints; i++) {
+    rCurrent = grid(i);
     chi_r_data(i) = integrator.Integrate(0.0, gamma, 1.0e-10);
   }
-  chi_r.Init(u.grid, chi_r_data);
+  chi_r.Init (u.grid, chi_r_data);
 
   // Finally, check to see if chi_r is small outside R0
-  Job          = CHECK_CHI_R;
+  Job = CHECK_CHI_R;
   double norm2 = integrator.Integrate(0.0, grid.End, 1.0e-8);
-  double error = integrator.Integrate(R0, grid.End, 1.0e-8);
+  double error = integrator.Integrate( R0, grid.End, 1.0e-8);
   if (error > 1.0e-16)
-    std::cerr << "Fractional error in real-space projection = " << (error / norm2) << std::endl;
+    std::cerr << "Fractional error in real-space projection = "
+	 << (error / norm2) << std::endl;
 }
 
 
-double NLPPClass::V(int l, double r)
+double
+NLPPClass::V(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V(r);
@@ -338,7 +338,8 @@ double NLPPClass::V(int l, double r)
     return Vl[lLocal].V(r);
 }
 
-double NLPPClass::dVdr(int l, double r)
+double
+NLPPClass::dVdr(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V.Deriv(r);
@@ -346,7 +347,8 @@ double NLPPClass::dVdr(int l, double r)
     return Vl[lLocal].V.Deriv(r);
 }
 
-double NLPPClass::d2Vdr2(int l, double r)
+double
+NLPPClass::d2Vdr2(int l, double r)
 {
   if (l < Vl.size())
     return Vl[l].V.Deriv2(r);
@@ -354,8 +356,20 @@ double NLPPClass::d2Vdr2(int l, double r)
     return Vl[lLocal].V.Deriv2(r);
 }
 
-double NLPPClass::V(double r) { return Vl[lLocal].V(r); }
+double
+NLPPClass::V(double r)
+{
+  return Vl[lLocal].V(r);
+}
 
-double NLPPClass::dVdr(double r) { return Vl[lLocal].V.Deriv(r); }
+double
+NLPPClass::dVdr(double r)
+{
+  return Vl[lLocal].V.Deriv(r);
+}
 
-double NLPPClass::d2Vdr2(double r) { return Vl[lLocal].V.Deriv2(r); }
+double
+NLPPClass::d2Vdr2(double r)
+{
+  return Vl[lLocal].V.Deriv2(r);
+}

--- a/src/QMCTools/ppconvert/src/common/NLPP.h
+++ b/src/QMCTools/ppconvert/src/common/NLPP.h
@@ -63,7 +63,7 @@ public:
   inline double operator()(double x);
 
   void SetupProjector(double G_max, double G_FFT);
-  void Read(IOSectionClass& in, Grid* grid);
+  void Read(IOSectionClass& in, std::shared_ptr<Grid>& grid);
   void Write(IOSectionClass& out);
 };
 
@@ -77,7 +77,7 @@ protected:
   double Zion;
   int AtomicNumber;
   std::string Symbol;
-  Grid* PotentialGrid;
+  std::shared_ptr<Grid> PotentialGrid;
 
 public:
   // General accessor functions

--- a/src/QMCTools/ppconvert/src/common/PotentialBase.h
+++ b/src/QMCTools/ppconvert/src/common/PotentialBase.h
@@ -22,6 +22,7 @@ using namespace IO;
 class Potential
 {
 public:
+  virtual ~Potential() = default;
   // Optional member functions -- if you're not a pseudoHamiltonian,
   // you do not need to define these
   virtual bool IsPH();

--- a/src/QMCTools/ppconvert/src/common/RadialWF.cc
+++ b/src/QMCTools/ppconvert/src/common/RadialWF.cc
@@ -8,91 +8,91 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
 #include "RadialWF.h"
 #include "RungeKutta.h"
 
-int 
-RadialWF::TurningIndex()
+int RadialWF::TurningIndex()
 {
   // Start in classically forbidden region and search inward toward
   // origin looking for classically allowed region
-  Grid &grid = *u.grid;
-  int index = grid.NumPoints-1;
-  bool done = false;
+  Grid& grid = *u.grid;
+  int index  = grid.NumPoints - 1;
+  bool done  = false;
 
-  while (!done && (index >=0))
-    {
-      double r = grid(index);
-      double A = pot->A(r);
-      double B = pot->B(r);
-      double V = pot->V(l,r);
-      double dAdr = pot->dAdr(r);
-      double E = Energy;
-      double sl = (double) l;
-      
-      double Deriv2 = dAdr/r + sl*(sl+1.0)*B/(r*r) + 2.0*(V-E);
-      
-      if (Deriv2 < 0.0)
-	done = true;
-      else
-	index--;
-    }
+  while (!done && (index >= 0))
+  {
+    double r    = grid(index);
+    double A    = pot->A(r);
+    double B    = pot->B(r);
+    double V    = pot->V(l, r);
+    double dAdr = pot->dAdr(r);
+    double E    = Energy;
+    double sl   = (double)l;
+
+    double Deriv2 = dAdr / r + sl * (sl + 1.0) * B / (r * r) + 2.0 * (V - E);
+
+    if (Deriv2 < 0.0)
+      done = true;
+    else
+      index--;
+  }
   // If we didn't fine a turning point, select the middle grid point;
   if (index == -1)
-    index = grid.ReverseMap(0.5*grid(grid.NumPoints-1));
+    index = grid.ReverseMap(0.5 * grid(grid.NumPoints - 1));
 
   return (index);
 }
-void 
-RadialWF::OriginBC(double r0, double &u0, double &du0)
+void RadialWF::OriginBC(double r0, double& u0, double& du0)
 {
-  if (pot->NeedsRel()) {  // Use relativistic equations
-    const double alpha = 1.0/137.036;
-    double Z = -pot->V(l,r0)*r0;
-    double a2Z2 = alpha*alpha*(double)Z*(double)Z;
-    
-    double sl = (double) l;
-    double gamma = 
-      (sl+1.0)*sqrt((sl+1.0)*(sl+1.0)-a2Z2) /
-      (2.0*sl + 1.0); 
-    if (l!=0)
-      gamma += sl*sqrt(sl*sl-a2Z2)/(2.0*sl+1.0);
-    
-    u0 = pow(r0, gamma);
-    du0 = gamma * pow(r0,gamma-1.0);
+  if (pot->NeedsRel())
+  { // Use relativistic equations
+    const double alpha = 1.0 / 137.036;
+    double Z           = -pot->V(l, r0) * r0;
+    double a2Z2        = alpha * alpha * (double)Z * (double)Z;
+
+    double sl    = (double)l;
+    double gamma = (sl + 1.0) * sqrt((sl + 1.0) * (sl + 1.0) - a2Z2) / (2.0 * sl + 1.0);
+    if (l != 0)
+      gamma += sl * sqrt(sl * sl - a2Z2) / (2.0 * sl + 1.0);
+
+    u0  = pow(r0, gamma);
+    du0 = gamma * pow(r0, gamma - 1.0);
   }
-  else  {  // Use pseudoHamiltonian equations
+  else
+  { // Use pseudoHamiltonian equations
     if (l == 0)
+    {
+      double E = Energy;
+      double A = pot->A(r0);
+      double B = pot->B(r0);
+      double V = pot->V(l, r0);
+      if (V > Energy)
       {
-	double E = Energy;
-	double A = pot->A(r0);
-	double B = pot->B(r0);
-	double V = pot->V(l,r0);
-	if (V > Energy)
-	  {
-	    double kappa = sqrt(2.0 * (V-E)/A);
-	    u0 = sinh(kappa * r0);
-	    du0 = kappa * cosh (kappa * r0);
-	  }
-	else
-	  {
-	    double k = sqrt(2.0 * (E-V)/A);
-	    u0 = sin(k * r0);
-	    du0 = k * cos(k * r0);
-	  }
+        double kappa = sqrt(2.0 * (V - E) / A);
+        u0           = sinh(kappa * r0);
+        du0          = kappa * cosh(kappa * r0);
       }
-    else {  // l != 0
-      u0 = 1.0;
-      du0 = (double)(l+1)/r0;
+      else
+      {
+        double k = sqrt(2.0 * (E - V) / A);
+        u0       = sin(k * r0);
+        du0      = k * cos(k * r0);
+      }
     }
-  }  
+    else
+    { // l != 0
+      u0  = 1.0;
+      du0 = (double)(l + 1) / r0;
+    }
+  }
   // Flip sign for odd number of nodes
-  if (((n-l-1) % 2) == 1)  {
+  if (((n - l - 1) % 2) == 1)
+  {
     u0 *= -1.0;
     du0 *= -1.0;
   }
@@ -105,7 +105,7 @@ RadialWF::OriginBC(double r0, double &u0, double &du0)
 //  Grid &grid = *u.grid;
 //  Array<Vec2,1> Temp(grid.NumPoints);
 //  // Set up initial conditions:
-//  double r0 = grid(0); 
+//  double r0 = grid(0);
 //  OriginBC(r0, Temp(0)[0], Temp(0)[1]);
 
 //  // Now do integration
@@ -117,12 +117,12 @@ RadialWF::OriginBC(double r0, double &u0, double &du0)
 //  else if (pot->NeedsRel()) {
 //    NonPHDerivs derivs(*this);
 //    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
-//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);    
+//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);
 //  }
 //  else {
 //    RegularDerivs derivs(*this);
 //    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
-//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);    
+//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);
 //  }
 
 //  // Copy results of integration into RadialWF
@@ -134,152 +134,159 @@ RadialWF::OriginBC(double r0, double &u0, double &du0)
 //}
 
 
-double 
-RadialWF::IntegrateInOut (int &tindex)
+double RadialWF::IntegrateInOut(int& tindex)
 {
-  Grid &grid = *u.grid;
+  Grid& grid = *u.grid;
   // Find classical turning point
   tindex = TurningIndex();
   //cerr << "TurningIndex = " << tindex << endl;
   //cerr << "Turning Point = " << (*u.grid)(tindex) << endl;
   // Compute starting value and derivative at origin
   double r0 = grid(0);
-  OriginBC (r0, uduVec(0)[0], uduVec(0)[1]);
+  OriginBC(r0, uduVec(0)[0], uduVec(0)[1]);
 
   // Do integration from the origin to the turning point
-  if (pot->IsPH()) {
+  if (pot->IsPH())
+  {
     PHDerivs derivs(*this);
-    RungeKutta<PHDerivs,Vec2> integrator(derivs);
+    RungeKutta<PHDerivs, Vec2> integrator(derivs);
     integrator.Integrate(grid, 0, tindex, uduVec);
   }
-  else if (pot->NeedsRel()) {
+  else if (pot->NeedsRel())
+  {
     NonPHDerivs derivs(*this);
-    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
-    integrator.Integrate(grid, 0, tindex, uduVec);    
+    RungeKutta<NonPHDerivs, Vec2> integrator(derivs);
+    integrator.Integrate(grid, 0, tindex, uduVec);
   }
-  else {
+  else
+  {
     RegularDerivs derivs(*this);
-    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
-    integrator.Integrate(grid, 0, tindex, uduVec);    
-  } 
+    RungeKutta<RegularDerivs, Vec2> integrator(derivs);
+    integrator.Integrate(grid, 0, tindex, uduVec);
+  }
 
-  for (int j=0; j<=tindex; j++) {
-    u(j) = uduVec(j)[0];
+  for (int j = 0; j <= tindex; j++)
+  {
+    u(j)    = uduVec(j)[0];
     dudr(j) = uduVec(j)[1];
   }
 
   // Now initilize value and derivative at rmax
-  int endPoint = grid.NumPoints-1;
-  double rend = grid(endPoint);
+  int endPoint = grid.NumPoints - 1;
+  double rend  = grid(endPoint);
   InfinityBC(rend, uduVec(endPoint)[0], uduVec(endPoint)[1]);
-  
-  // Do integration from the right to the turning point
-  if (pot->IsPH()) {
-    PHDerivs derivs(*this);
-    RungeKutta<PHDerivs,Vec2> integrator(derivs);
-    integrator.Integrate(grid, endPoint, tindex, uduVec);
-  }
-  else if (pot->NeedsRel()) {
-    NonPHDerivs derivs(*this);
-    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
-    integrator.Integrate(grid, endPoint, tindex, uduVec);
-  }
-  else {
-    RegularDerivs derivs(*this);
-    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
-    integrator.Integrate(grid, endPoint, tindex, uduVec);    
-  } 
 
-  if ((u(tindex)*uduVec(tindex)[0]) < 0.0)
-    for (int i=tindex; i<=endPoint; i++)
+  // Do integration from the right to the turning point
+  if (pot->IsPH())
+  {
+    PHDerivs derivs(*this);
+    RungeKutta<PHDerivs, Vec2> integrator(derivs);
+    integrator.Integrate(grid, endPoint, tindex, uduVec);
+  }
+  else if (pot->NeedsRel())
+  {
+    NonPHDerivs derivs(*this);
+    RungeKutta<NonPHDerivs, Vec2> integrator(derivs);
+    integrator.Integrate(grid, endPoint, tindex, uduVec);
+  }
+  else
+  {
+    RegularDerivs derivs(*this);
+    RungeKutta<RegularDerivs, Vec2> integrator(derivs);
+    integrator.Integrate(grid, endPoint, tindex, uduVec);
+  }
+
+  if ((u(tindex) * uduVec(tindex)[0]) < 0.0)
+    for (int i = tindex; i <= endPoint; i++)
       uduVec(i) *= -1.0;
 
-  double cuspValue = uduVec(tindex)[1]/uduVec(tindex)[0] -
-    dudr(tindex)/u(tindex);
+  double cuspValue = uduVec(tindex)[1] / uduVec(tindex)[0] - dudr(tindex) / u(tindex);
 
   // Copy values in, normalizing to make R continuous
   double factor = u(tindex) / uduVec(tindex)[0];
-  for (int i=tindex+1; i<grid.NumPoints; i++) {
-    u(i)    = factor*uduVec(i)[0];
-    dudr(i) = factor*uduVec(i)[1];
+  for (int i = tindex + 1; i < grid.NumPoints; i++)
+  {
+    u(i)    = factor * uduVec(i)[0];
+    dudr(i) = factor * uduVec(i)[1];
   }
   return (cuspValue);
 }
 
 
-
-void 
-RadialWF::InfinityBC(double rend, double &uend, double &duend)
+void RadialWF::InfinityBC(double rend, double& uend, double& duend)
 {
   // Infinity should be outside core, so we don't need to worry about
   // A and B.
-  double Vend = pot->V(l,rend);
-  double dVdrend = pot->dVdr(l,rend);
-  double E = Energy;
+  double Vend    = pot->V(l, rend);
+  double dVdrend = pot->dVdr(l, rend);
+  double E       = Energy;
   double k;
   uend = 1.0;
-  if (Vend > E) {
-    k = sqrt(l*(l+1.0)/(rend*rend) + (Vend-E));
-    duend = -uend * (k + 0.5*rend/k*(dVdrend-2.0*l*(l+1.0)/(rend*rend*rend)));
+  if (Vend > E)
+  {
+    k     = sqrt(l * (l + 1.0) / (rend * rend) + (Vend - E));
+    duend = -uend * (k + 0.5 * rend / k * (dVdrend - 2.0 * l * (l + 1.0) / (rend * rend * rend)));
   }
   else
     duend = -1.0;
 
 
-//   cerr << "duend = " << duend << endl;
-//   cerr << "rend = " << rend << endl;
-//   cerr << "k = " << k << endl;
-//   cerr << "Vend = " << Vend << endl;
-//   cerr << "dVend = " << dVdrend << endl;
+  //   cerr << "duend = " << duend << endl;
+  //   cerr << "rend = " << rend << endl;
+  //   cerr << "k = " << k << endl;
+  //   cerr << "Vend = " << Vend << endl;
+  //   cerr << "dVend = " << dVdrend << endl;
 }
 
 
-
-void 
-RadialWF::Solve(double tolerance)
+void RadialWF::Solve(double tolerance)
 {
   int tindex;
   IntegrateInOut(tindex);
   int NumNodes = CountNodes();
   double Ehigh, Elow, Etrial;
-  Ehigh = 0.0;
-  Grid &grid = *u.grid;
-  int TotalNodes = n-l-1;
+  Ehigh          = 0.0;
+  Grid& grid     = *u.grid;
+  int TotalNodes = n - l - 1;
 
-//   char fname[100];
-//   snprintf (fname, 100, "WFn%dl%d.h5", n, l);
-//   IOSectionClass out;
-//   out.NewFile(fname);    
-//   out.WriteVar ("x", u.grid->Points());
-//   Array<double,2> tmp(1,u.grid->NumPoints);
-//   tmp(0,Range::all()) = u.Data();
-//   out.WriteVar ("u", tmp);
-//   VarClass *varPtr = out.GetVarPtr("u");
+  //   char fname[100];
+  //   snprintf (fname, 100, "WFn%dl%d.h5", n, l);
+  //   IOSectionClass out;
+  //   out.NewFile(fname);
+  //   out.WriteVar ("x", u.grid->Points());
+  //   Array<double,2> tmp(1,u.grid->NumPoints);
+  //   tmp(0,Range::all()) = u.Data();
+  //   out.WriteVar ("u", tmp);
+  //   VarClass *varPtr = out.GetVarPtr("u");
 
-  if (pot->NeedsRel()){
+  if (pot->NeedsRel())
+  {
     double N = n;
-    double Z = -pot->V(l,grid(0))*grid(0);
-    Elow = -1.5*Z*Z/(N*N);
-  } 
-  else {
+    double Z = -pot->V(l, grid(0)) * grid(0);
+    Elow     = -1.5 * Z * Z / (N * N);
+  }
+  else
+  {
     // Eigenenergy can't be lower than lowest potential -- otherwise
     // we'd have no turning point.
-    Elow = pot->V(l,grid(0));
-    for (int i=1; i<grid.NumPoints; i++) {
+    Elow = pot->V(l, grid(0));
+    for (int i = 1; i < grid.NumPoints; i++)
+    {
       double r = grid(i);
       // cerr << "r = " << r << "   V(l,r) = " << pot->V(l,r) << endl;
-      if (pot->V(l,r) < Elow)
-	Elow = pot->V(l,r);
+      if (pot->V(l, r) < Elow)
+        Elow = pot->V(l, r);
     }
   }
 
   double Eold;
   Eold = Etrial = Energy;
-  bool done = false;
-  while (!done) {
+  bool done     = false;
+  while (!done)
+  {
     // cerr << "Ehigh = " << Ehigh << " Elow = " << Elow << endl;
     double CuspValue = IntegrateInOut(tindex);
-    //cerr << "Cusp value = " << CuspValue << "\n";    
+    //cerr << "Cusp value = " << CuspValue << "\n";
     NumNodes = CountNodes();
     if (NumNodes > TotalNodes)
       Ehigh = Etrial;
@@ -291,27 +298,28 @@ RadialWF::Solve(double tolerance)
       Ehigh = Etrial;
     else if (std::isnan(CuspValue))
       Elow = Etrial;
-    
+
     Normalize();
     // varPtr->Append(u.Data());
-    double A = pot->A(grid(tindex));
-    double C = 0.5 * A * CuspValue;
-    double u0 = u(tindex);
-    double Etest = Eold - 4.0*M_PI*C*u0*u0;
+    double A     = pot->A(grid(tindex));
+    double C     = 0.5 * A * CuspValue;
+    double u0    = u(tindex);
+    double Etest = Eold - 4.0 * M_PI * C * u0 * u0;
     if ((Etest > Elow) && (Etest < Ehigh) && (NumNodes == TotalNodes))
       Etrial = Etest;
-    else 
+    else
       Etrial = 0.5 * (Ehigh + Elow);
-    
+
     Energy = Etrial;
-    
-    if ((NumNodes == TotalNodes) && (fabs(Etrial - Eold) < tolerance)) {
+
+    if ((NumNodes == TotalNodes) && (fabs(Etrial - Eold) < tolerance))
+    {
       Energy = Eold;
-      done = true;
+      done   = true;
     }
     else
     {
-      if(std::isnan(Etrial))
+      if (std::isnan(Etrial))
       {
         std::cerr << "NaN detected!" << std::endl;
         std::cerr << "NumNodes = " << NumNodes << " TotalNodes = " << TotalNodes << std::endl;
@@ -319,48 +327,48 @@ RadialWF::Solve(double tolerance)
         exit(1);
       }
     }
-    Eold = Etrial;       
+    Eold = Etrial;
   }
   IntegrateInOut(tindex);
   Normalize();
   NumNodes = CountNodes();
-  if (NumNodes != TotalNodes) {
-    std::cerr << "Node number error!  We have " << NumNodes 
-	 << " nodes and want " << TotalNodes << ".\n";
-//     IOSectionClass out;
-//     out.NewFile ("BadWF.h5");
-//     out.WriteVar ("u", u.Data());
-//     out.CloseFile();
+  if (NumNodes != TotalNodes)
+  {
+    std::cerr << "Node number error!  We have " << NumNodes << " nodes and want " << TotalNodes << ".\n";
+    //     IOSectionClass out;
+    //     out.NewFile ("BadWF.h5");
+    //     out.WriteVar ("u", u.Data());
+    //     out.CloseFile();
     std::cerr << "Energy = " << Energy << std::endl;
   }
   //out.CloseFile();
 }
 
 
-void 
-RadialWF::Normalize()
+void RadialWF::Normalize()
 {
   normVec(0) = 0.0;
   NormalizeDeriv normDeriv(*this);
-  RungeKutta<NormalizeDeriv,double> integrator(normDeriv);
-  // The false means "don't scale" 
-  integrator.Integrate(*u.grid, 0, u.grid->NumPoints-1, normVec, false);
-  
-  double norm = sqrt(1.0/(4.0*M_PI*normVec(u.grid->NumPoints-1)));
-  for (int i=0; i<u.grid->NumPoints; i++) {
+  RungeKutta<NormalizeDeriv, double> integrator(normDeriv);
+  // The false means "don't scale"
+  integrator.Integrate(*u.grid, 0, u.grid->NumPoints - 1, normVec, false);
+
+  double norm = sqrt(1.0 / (4.0 * M_PI * normVec(u.grid->NumPoints - 1)));
+  for (int i = 0; i < u.grid->NumPoints; i++)
+  {
     u(i) *= norm;
     dudr(i) *= norm;
   }
 }
 
 
-int 
-RadialWF::CountNodes()
+int RadialWF::CountNodes()
 {
-  int nodes=0;
+  int nodes   = 0;
   double sign = u(0);
-  for (int i=1; i<u.grid->NumPoints; i++)
-    if ((sign*u(i)) < 0.0) {
+  for (int i = 1; i < u.grid->NumPoints; i++)
+    if ((sign * u(i)) < 0.0)
+    {
       nodes++;
       sign *= -1.0;
       //      cerr << "Node at i=" << i << " r=" << (*u.grid)(i) << endl;
@@ -368,79 +376,67 @@ RadialWF::CountNodes()
   return (nodes);
 }
 
-void 
-RadialWF::SetGrid(Grid *newgrid)
+void RadialWF::SetGrid(std::shared_ptr<Grid>& newgrid)
 {
-  grid = newgrid;
+  grid  = newgrid;
   int N = grid->NumPoints;
   uduVec.resize(N);
   normVec.resize(N);
-  uduVec = 0.0;
+  uduVec  = 0.0;
   normVec = 0.0;
-  u.Init (grid, normVec);
+  u.Init(grid, normVec);
   dudr.Init(grid, normVec);
 }
 
-void 
-RadialWF::SetPotential(Potential *newPot)
-{
-  pot = newPot;
-}
+void RadialWF::SetPotential(Potential* newPot) { pot = newPot; }
 
-Potential* 
-RadialWF::GetPotential()
-{
-  return pot;
-}
+Potential* RadialWF::GetPotential() { return pot; }
 
-double 
-RadialWF::PartialNorm()
+double RadialWF::PartialNorm()
 {
   normVec(0) = 0.0;
   NormalizeDeriv normDeriv(*this);
-  RungeKutta<NormalizeDeriv,double> integrator(normDeriv);
+  RungeKutta<NormalizeDeriv, double> integrator(normDeriv);
   int N = u.grid->NumPoints;
-  integrator.Integrate(*u.grid, 0, N-1, normVec);
-  double uend = u(N-1);
-  double partNorm = normVec(N-1)/(uend*uend);
+  integrator.Integrate(*u.grid, 0, N - 1, normVec);
+  double uend     = u(N - 1);
+  double partNorm = normVec(N - 1) / (uend * uend);
   return (partNorm);
 }
 
-double 
-RadialWF::LogDerivative()
+double RadialWF::LogDerivative()
 {
   double rend = (*u.grid).End;
-  return (dudr(rend)/u(rend));
+  return (dudr(rend) / u(rend));
 }
 
 // This will write all the information except the potential and the
 // grid.  We assume that those are store somewhere else
-void 
-RadialWF::Write(IOSectionClass &out)
+void RadialWF::Write(IOSectionClass& out)
 {
-  out.WriteVar ("u", u.Data());
-  out.WriteVar ("dudr", dudr.Data());
-  out.WriteVar ("n", n);
-  out.WriteVar ("l", l);
-  out.WriteVar ("CoreNodes", CoreNodes);
-  out.WriteVar ("Occupancy", Occupancy);
-  out.WriteVar ("Weight", Weight);
-  out.WriteVar ("Energy", Energy);
+  out.WriteVar("u", u.Data());
+  out.WriteVar("dudr", dudr.Data());
+  out.WriteVar("n", n);
+  out.WriteVar("l", l);
+  out.WriteVar("CoreNodes", CoreNodes);
+  out.WriteVar("Occupancy", Occupancy);
+  out.WriteVar("Weight", Weight);
+  out.WriteVar("Energy", Energy);
   //  out.WriteVar ("PartialNorm", PartialNorm);
-  out.WriteVar ("Label", Label);
+  out.WriteVar("Label", Label);
 }
 
 // This function assumes the grid has already been set.
-void 
-RadialWF::Read (IOSectionClass &in)
+void RadialWF::Read(IOSectionClass& in)
 {
   bool succ;
-  if (u.grid == NULL) {
+  if (u.grid == NULL)
+  {
     std::cerr << "Grid not set prior to calling RadialWF::Read.\n";
     exit(1);
   }
-  in.ReadVar ("u", u.Data());
-  in.ReadVar ("dudr", dudr.Data());
+  in.ReadVar("u", u.Data());
+  in.ReadVar("dudr", dudr.Data());
   assert(in.ReadVar("n", n));
   assert(in.ReadVar("l", l));
   assert(in.ReadVar("Occupancy", Occupancy));

--- a/src/QMCTools/ppconvert/src/common/RadialWF.cc
+++ b/src/QMCTools/ppconvert/src/common/RadialWF.cc
@@ -8,91 +8,91 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-
-
+    
+    
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
 #include "RadialWF.h"
 #include "RungeKutta.h"
 
-int RadialWF::TurningIndex()
+int 
+RadialWF::TurningIndex()
 {
   // Start in classically forbidden region and search inward toward
   // origin looking for classically allowed region
-  Grid& grid = *u.grid;
-  int index  = grid.NumPoints - 1;
-  bool done  = false;
+  Grid &grid = *u.grid;
+  int index = grid.NumPoints-1;
+  bool done = false;
 
-  while (!done && (index >= 0))
-  {
-    double r    = grid(index);
-    double A    = pot->A(r);
-    double B    = pot->B(r);
-    double V    = pot->V(l, r);
-    double dAdr = pot->dAdr(r);
-    double E    = Energy;
-    double sl   = (double)l;
-
-    double Deriv2 = dAdr / r + sl * (sl + 1.0) * B / (r * r) + 2.0 * (V - E);
-
-    if (Deriv2 < 0.0)
-      done = true;
-    else
-      index--;
-  }
+  while (!done && (index >=0))
+    {
+      double r = grid(index);
+      double A = pot->A(r);
+      double B = pot->B(r);
+      double V = pot->V(l,r);
+      double dAdr = pot->dAdr(r);
+      double E = Energy;
+      double sl = (double) l;
+      
+      double Deriv2 = dAdr/r + sl*(sl+1.0)*B/(r*r) + 2.0*(V-E);
+      
+      if (Deriv2 < 0.0)
+	done = true;
+      else
+	index--;
+    }
   // If we didn't fine a turning point, select the middle grid point;
   if (index == -1)
-    index = grid.ReverseMap(0.5 * grid(grid.NumPoints - 1));
+    index = grid.ReverseMap(0.5*grid(grid.NumPoints-1));
 
   return (index);
 }
-void RadialWF::OriginBC(double r0, double& u0, double& du0)
+void 
+RadialWF::OriginBC(double r0, double &u0, double &du0)
 {
-  if (pot->NeedsRel())
-  { // Use relativistic equations
-    const double alpha = 1.0 / 137.036;
-    double Z           = -pot->V(l, r0) * r0;
-    double a2Z2        = alpha * alpha * (double)Z * (double)Z;
-
-    double sl    = (double)l;
-    double gamma = (sl + 1.0) * sqrt((sl + 1.0) * (sl + 1.0) - a2Z2) / (2.0 * sl + 1.0);
-    if (l != 0)
-      gamma += sl * sqrt(sl * sl - a2Z2) / (2.0 * sl + 1.0);
-
-    u0  = pow(r0, gamma);
-    du0 = gamma * pow(r0, gamma - 1.0);
+  if (pot->NeedsRel()) {  // Use relativistic equations
+    const double alpha = 1.0/137.036;
+    double Z = -pot->V(l,r0)*r0;
+    double a2Z2 = alpha*alpha*(double)Z*(double)Z;
+    
+    double sl = (double) l;
+    double gamma = 
+      (sl+1.0)*sqrt((sl+1.0)*(sl+1.0)-a2Z2) /
+      (2.0*sl + 1.0); 
+    if (l!=0)
+      gamma += sl*sqrt(sl*sl-a2Z2)/(2.0*sl+1.0);
+    
+    u0 = pow(r0, gamma);
+    du0 = gamma * pow(r0,gamma-1.0);
   }
-  else
-  { // Use pseudoHamiltonian equations
+  else  {  // Use pseudoHamiltonian equations
     if (l == 0)
-    {
-      double E = Energy;
-      double A = pot->A(r0);
-      double B = pot->B(r0);
-      double V = pot->V(l, r0);
-      if (V > Energy)
       {
-        double kappa = sqrt(2.0 * (V - E) / A);
-        u0           = sinh(kappa * r0);
-        du0          = kappa * cosh(kappa * r0);
+	double E = Energy;
+	double A = pot->A(r0);
+	double B = pot->B(r0);
+	double V = pot->V(l,r0);
+	if (V > Energy)
+	  {
+	    double kappa = sqrt(2.0 * (V-E)/A);
+	    u0 = sinh(kappa * r0);
+	    du0 = kappa * cosh (kappa * r0);
+	  }
+	else
+	  {
+	    double k = sqrt(2.0 * (E-V)/A);
+	    u0 = sin(k * r0);
+	    du0 = k * cos(k * r0);
+	  }
       }
-      else
-      {
-        double k = sqrt(2.0 * (E - V) / A);
-        u0       = sin(k * r0);
-        du0      = k * cos(k * r0);
-      }
+    else {  // l != 0
+      u0 = 1.0;
+      du0 = (double)(l+1)/r0;
     }
-    else
-    { // l != 0
-      u0  = 1.0;
-      du0 = (double)(l + 1) / r0;
-    }
-  }
+  }  
   // Flip sign for odd number of nodes
-  if (((n - l - 1) % 2) == 1)
-  {
+  if (((n-l-1) % 2) == 1)  {
     u0 *= -1.0;
     du0 *= -1.0;
   }
@@ -105,7 +105,7 @@ void RadialWF::OriginBC(double r0, double& u0, double& du0)
 //  Grid &grid = *u.grid;
 //  Array<Vec2,1> Temp(grid.NumPoints);
 //  // Set up initial conditions:
-//  double r0 = grid(0);
+//  double r0 = grid(0); 
 //  OriginBC(r0, Temp(0)[0], Temp(0)[1]);
 
 //  // Now do integration
@@ -117,12 +117,12 @@ void RadialWF::OriginBC(double r0, double& u0, double& du0)
 //  else if (pot->NeedsRel()) {
 //    NonPHDerivs derivs(*this);
 //    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
-//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);
+//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);    
 //  }
 //  else {
 //    RegularDerivs derivs(*this);
 //    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
-//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);
+//    integrator.Integrate(grid, 0, grid.NumPoints-1, Temp);    
 //  }
 
 //  // Copy results of integration into RadialWF
@@ -134,159 +134,152 @@ void RadialWF::OriginBC(double r0, double& u0, double& du0)
 //}
 
 
-double RadialWF::IntegrateInOut(int& tindex)
+double 
+RadialWF::IntegrateInOut (int &tindex)
 {
-  Grid& grid = *u.grid;
+  Grid &grid = *u.grid;
   // Find classical turning point
   tindex = TurningIndex();
   //cerr << "TurningIndex = " << tindex << endl;
   //cerr << "Turning Point = " << (*u.grid)(tindex) << endl;
   // Compute starting value and derivative at origin
   double r0 = grid(0);
-  OriginBC(r0, uduVec(0)[0], uduVec(0)[1]);
+  OriginBC (r0, uduVec(0)[0], uduVec(0)[1]);
 
   // Do integration from the origin to the turning point
-  if (pot->IsPH())
-  {
+  if (pot->IsPH()) {
     PHDerivs derivs(*this);
-    RungeKutta<PHDerivs, Vec2> integrator(derivs);
+    RungeKutta<PHDerivs,Vec2> integrator(derivs);
     integrator.Integrate(grid, 0, tindex, uduVec);
   }
-  else if (pot->NeedsRel())
-  {
+  else if (pot->NeedsRel()) {
     NonPHDerivs derivs(*this);
-    RungeKutta<NonPHDerivs, Vec2> integrator(derivs);
-    integrator.Integrate(grid, 0, tindex, uduVec);
+    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
+    integrator.Integrate(grid, 0, tindex, uduVec);    
   }
-  else
-  {
+  else {
     RegularDerivs derivs(*this);
-    RungeKutta<RegularDerivs, Vec2> integrator(derivs);
-    integrator.Integrate(grid, 0, tindex, uduVec);
-  }
+    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
+    integrator.Integrate(grid, 0, tindex, uduVec);    
+  } 
 
-  for (int j = 0; j <= tindex; j++)
-  {
-    u(j)    = uduVec(j)[0];
+  for (int j=0; j<=tindex; j++) {
+    u(j) = uduVec(j)[0];
     dudr(j) = uduVec(j)[1];
   }
 
   // Now initilize value and derivative at rmax
-  int endPoint = grid.NumPoints - 1;
-  double rend  = grid(endPoint);
+  int endPoint = grid.NumPoints-1;
+  double rend = grid(endPoint);
   InfinityBC(rend, uduVec(endPoint)[0], uduVec(endPoint)[1]);
-
+  
   // Do integration from the right to the turning point
-  if (pot->IsPH())
-  {
+  if (pot->IsPH()) {
     PHDerivs derivs(*this);
-    RungeKutta<PHDerivs, Vec2> integrator(derivs);
+    RungeKutta<PHDerivs,Vec2> integrator(derivs);
     integrator.Integrate(grid, endPoint, tindex, uduVec);
   }
-  else if (pot->NeedsRel())
-  {
+  else if (pot->NeedsRel()) {
     NonPHDerivs derivs(*this);
-    RungeKutta<NonPHDerivs, Vec2> integrator(derivs);
+    RungeKutta<NonPHDerivs,Vec2> integrator(derivs);
     integrator.Integrate(grid, endPoint, tindex, uduVec);
   }
-  else
-  {
+  else {
     RegularDerivs derivs(*this);
-    RungeKutta<RegularDerivs, Vec2> integrator(derivs);
-    integrator.Integrate(grid, endPoint, tindex, uduVec);
-  }
+    RungeKutta<RegularDerivs,Vec2> integrator(derivs);
+    integrator.Integrate(grid, endPoint, tindex, uduVec);    
+  } 
 
-  if ((u(tindex) * uduVec(tindex)[0]) < 0.0)
-    for (int i = tindex; i <= endPoint; i++)
+  if ((u(tindex)*uduVec(tindex)[0]) < 0.0)
+    for (int i=tindex; i<=endPoint; i++)
       uduVec(i) *= -1.0;
 
-  double cuspValue = uduVec(tindex)[1] / uduVec(tindex)[0] - dudr(tindex) / u(tindex);
+  double cuspValue = uduVec(tindex)[1]/uduVec(tindex)[0] -
+    dudr(tindex)/u(tindex);
 
   // Copy values in, normalizing to make R continuous
   double factor = u(tindex) / uduVec(tindex)[0];
-  for (int i = tindex + 1; i < grid.NumPoints; i++)
-  {
-    u(i)    = factor * uduVec(i)[0];
-    dudr(i) = factor * uduVec(i)[1];
+  for (int i=tindex+1; i<grid.NumPoints; i++) {
+    u(i)    = factor*uduVec(i)[0];
+    dudr(i) = factor*uduVec(i)[1];
   }
   return (cuspValue);
 }
 
 
-void RadialWF::InfinityBC(double rend, double& uend, double& duend)
+
+void 
+RadialWF::InfinityBC(double rend, double &uend, double &duend)
 {
   // Infinity should be outside core, so we don't need to worry about
   // A and B.
-  double Vend    = pot->V(l, rend);
-  double dVdrend = pot->dVdr(l, rend);
-  double E       = Energy;
+  double Vend = pot->V(l,rend);
+  double dVdrend = pot->dVdr(l,rend);
+  double E = Energy;
   double k;
   uend = 1.0;
-  if (Vend > E)
-  {
-    k     = sqrt(l * (l + 1.0) / (rend * rend) + (Vend - E));
-    duend = -uend * (k + 0.5 * rend / k * (dVdrend - 2.0 * l * (l + 1.0) / (rend * rend * rend)));
+  if (Vend > E) {
+    k = sqrt(l*(l+1.0)/(rend*rend) + (Vend-E));
+    duend = -uend * (k + 0.5*rend/k*(dVdrend-2.0*l*(l+1.0)/(rend*rend*rend)));
   }
   else
     duend = -1.0;
 
 
-  //   cerr << "duend = " << duend << endl;
-  //   cerr << "rend = " << rend << endl;
-  //   cerr << "k = " << k << endl;
-  //   cerr << "Vend = " << Vend << endl;
-  //   cerr << "dVend = " << dVdrend << endl;
+//   cerr << "duend = " << duend << endl;
+//   cerr << "rend = " << rend << endl;
+//   cerr << "k = " << k << endl;
+//   cerr << "Vend = " << Vend << endl;
+//   cerr << "dVend = " << dVdrend << endl;
 }
 
 
-void RadialWF::Solve(double tolerance)
+
+void 
+RadialWF::Solve(double tolerance)
 {
   int tindex;
   IntegrateInOut(tindex);
   int NumNodes = CountNodes();
   double Ehigh, Elow, Etrial;
-  Ehigh          = 0.0;
-  Grid& grid     = *u.grid;
-  int TotalNodes = n - l - 1;
+  Ehigh = 0.0;
+  Grid &grid = *u.grid;
+  int TotalNodes = n-l-1;
 
-  //   char fname[100];
-  //   snprintf (fname, 100, "WFn%dl%d.h5", n, l);
-  //   IOSectionClass out;
-  //   out.NewFile(fname);
-  //   out.WriteVar ("x", u.grid->Points());
-  //   Array<double,2> tmp(1,u.grid->NumPoints);
-  //   tmp(0,Range::all()) = u.Data();
-  //   out.WriteVar ("u", tmp);
-  //   VarClass *varPtr = out.GetVarPtr("u");
+//   char fname[100];
+//   snprintf (fname, 100, "WFn%dl%d.h5", n, l);
+//   IOSectionClass out;
+//   out.NewFile(fname);    
+//   out.WriteVar ("x", u.grid->Points());
+//   Array<double,2> tmp(1,u.grid->NumPoints);
+//   tmp(0,Range::all()) = u.Data();
+//   out.WriteVar ("u", tmp);
+//   VarClass *varPtr = out.GetVarPtr("u");
 
-  if (pot->NeedsRel())
-  {
+  if (pot->NeedsRel()){
     double N = n;
-    double Z = -pot->V(l, grid(0)) * grid(0);
-    Elow     = -1.5 * Z * Z / (N * N);
-  }
-  else
-  {
+    double Z = -pot->V(l,grid(0))*grid(0);
+    Elow = -1.5*Z*Z/(N*N);
+  } 
+  else {
     // Eigenenergy can't be lower than lowest potential -- otherwise
     // we'd have no turning point.
-    Elow = pot->V(l, grid(0));
-    for (int i = 1; i < grid.NumPoints; i++)
-    {
+    Elow = pot->V(l,grid(0));
+    for (int i=1; i<grid.NumPoints; i++) {
       double r = grid(i);
       // cerr << "r = " << r << "   V(l,r) = " << pot->V(l,r) << endl;
-      if (pot->V(l, r) < Elow)
-        Elow = pot->V(l, r);
+      if (pot->V(l,r) < Elow)
+	Elow = pot->V(l,r);
     }
   }
 
   double Eold;
   Eold = Etrial = Energy;
-  bool done     = false;
-  while (!done)
-  {
+  bool done = false;
+  while (!done) {
     // cerr << "Ehigh = " << Ehigh << " Elow = " << Elow << endl;
     double CuspValue = IntegrateInOut(tindex);
-    //cerr << "Cusp value = " << CuspValue << "\n";
+    //cerr << "Cusp value = " << CuspValue << "\n";    
     NumNodes = CountNodes();
     if (NumNodes > TotalNodes)
       Ehigh = Etrial;
@@ -298,28 +291,27 @@ void RadialWF::Solve(double tolerance)
       Ehigh = Etrial;
     else if (std::isnan(CuspValue))
       Elow = Etrial;
-
+    
     Normalize();
     // varPtr->Append(u.Data());
-    double A     = pot->A(grid(tindex));
-    double C     = 0.5 * A * CuspValue;
-    double u0    = u(tindex);
-    double Etest = Eold - 4.0 * M_PI * C * u0 * u0;
+    double A = pot->A(grid(tindex));
+    double C = 0.5 * A * CuspValue;
+    double u0 = u(tindex);
+    double Etest = Eold - 4.0*M_PI*C*u0*u0;
     if ((Etest > Elow) && (Etest < Ehigh) && (NumNodes == TotalNodes))
       Etrial = Etest;
-    else
+    else 
       Etrial = 0.5 * (Ehigh + Elow);
-
+    
     Energy = Etrial;
-
-    if ((NumNodes == TotalNodes) && (fabs(Etrial - Eold) < tolerance))
-    {
+    
+    if ((NumNodes == TotalNodes) && (fabs(Etrial - Eold) < tolerance)) {
       Energy = Eold;
-      done   = true;
+      done = true;
     }
     else
     {
-      if (std::isnan(Etrial))
+      if(std::isnan(Etrial))
       {
         std::cerr << "NaN detected!" << std::endl;
         std::cerr << "NumNodes = " << NumNodes << " TotalNodes = " << TotalNodes << std::endl;
@@ -327,48 +319,48 @@ void RadialWF::Solve(double tolerance)
         exit(1);
       }
     }
-    Eold = Etrial;
+    Eold = Etrial;       
   }
   IntegrateInOut(tindex);
   Normalize();
   NumNodes = CountNodes();
-  if (NumNodes != TotalNodes)
-  {
-    std::cerr << "Node number error!  We have " << NumNodes << " nodes and want " << TotalNodes << ".\n";
-    //     IOSectionClass out;
-    //     out.NewFile ("BadWF.h5");
-    //     out.WriteVar ("u", u.Data());
-    //     out.CloseFile();
+  if (NumNodes != TotalNodes) {
+    std::cerr << "Node number error!  We have " << NumNodes 
+	 << " nodes and want " << TotalNodes << ".\n";
+//     IOSectionClass out;
+//     out.NewFile ("BadWF.h5");
+//     out.WriteVar ("u", u.Data());
+//     out.CloseFile();
     std::cerr << "Energy = " << Energy << std::endl;
   }
   //out.CloseFile();
 }
 
 
-void RadialWF::Normalize()
+void 
+RadialWF::Normalize()
 {
   normVec(0) = 0.0;
   NormalizeDeriv normDeriv(*this);
-  RungeKutta<NormalizeDeriv, double> integrator(normDeriv);
-  // The false means "don't scale"
-  integrator.Integrate(*u.grid, 0, u.grid->NumPoints - 1, normVec, false);
-
-  double norm = sqrt(1.0 / (4.0 * M_PI * normVec(u.grid->NumPoints - 1)));
-  for (int i = 0; i < u.grid->NumPoints; i++)
-  {
+  RungeKutta<NormalizeDeriv,double> integrator(normDeriv);
+  // The false means "don't scale" 
+  integrator.Integrate(*u.grid, 0, u.grid->NumPoints-1, normVec, false);
+  
+  double norm = sqrt(1.0/(4.0*M_PI*normVec(u.grid->NumPoints-1)));
+  for (int i=0; i<u.grid->NumPoints; i++) {
     u(i) *= norm;
     dudr(i) *= norm;
   }
 }
 
 
-int RadialWF::CountNodes()
+int 
+RadialWF::CountNodes()
 {
-  int nodes   = 0;
+  int nodes=0;
   double sign = u(0);
-  for (int i = 1; i < u.grid->NumPoints; i++)
-    if ((sign * u(i)) < 0.0)
-    {
+  for (int i=1; i<u.grid->NumPoints; i++)
+    if ((sign*u(i)) < 0.0) {
       nodes++;
       sign *= -1.0;
       //      cerr << "Node at i=" << i << " r=" << (*u.grid)(i) << endl;
@@ -376,67 +368,79 @@ int RadialWF::CountNodes()
   return (nodes);
 }
 
-void RadialWF::SetGrid(std::shared_ptr<Grid>& newgrid)
+void 
+RadialWF::SetGrid(std::shared_ptr<Grid>& newgrid)
 {
-  grid  = newgrid;
+  grid = newgrid;
   int N = grid->NumPoints;
   uduVec.resize(N);
   normVec.resize(N);
-  uduVec  = 0.0;
+  uduVec = 0.0;
   normVec = 0.0;
-  u.Init(grid, normVec);
+  u.Init (grid, normVec);
   dudr.Init(grid, normVec);
 }
 
-void RadialWF::SetPotential(Potential* newPot) { pot = newPot; }
+void 
+RadialWF::SetPotential(Potential *newPot)
+{
+  pot = newPot;
+}
 
-Potential* RadialWF::GetPotential() { return pot; }
+Potential* 
+RadialWF::GetPotential()
+{
+  return pot;
+}
 
-double RadialWF::PartialNorm()
+double 
+RadialWF::PartialNorm()
 {
   normVec(0) = 0.0;
   NormalizeDeriv normDeriv(*this);
-  RungeKutta<NormalizeDeriv, double> integrator(normDeriv);
+  RungeKutta<NormalizeDeriv,double> integrator(normDeriv);
   int N = u.grid->NumPoints;
-  integrator.Integrate(*u.grid, 0, N - 1, normVec);
-  double uend     = u(N - 1);
-  double partNorm = normVec(N - 1) / (uend * uend);
+  integrator.Integrate(*u.grid, 0, N-1, normVec);
+  double uend = u(N-1);
+  double partNorm = normVec(N-1)/(uend*uend);
   return (partNorm);
 }
 
-double RadialWF::LogDerivative()
+double 
+RadialWF::LogDerivative()
 {
   double rend = (*u.grid).End;
-  return (dudr(rend) / u(rend));
+  return (dudr(rend)/u(rend));
 }
 
 // This will write all the information except the potential and the
 // grid.  We assume that those are store somewhere else
-void RadialWF::Write(IOSectionClass& out)
+void 
+RadialWF::Write(IOSectionClass &out)
 {
-  out.WriteVar("u", u.Data());
-  out.WriteVar("dudr", dudr.Data());
-  out.WriteVar("n", n);
-  out.WriteVar("l", l);
-  out.WriteVar("CoreNodes", CoreNodes);
-  out.WriteVar("Occupancy", Occupancy);
-  out.WriteVar("Weight", Weight);
-  out.WriteVar("Energy", Energy);
+  out.WriteVar ("u", u.Data());
+  out.WriteVar ("dudr", dudr.Data());
+  out.WriteVar ("n", n);
+  out.WriteVar ("l", l);
+  out.WriteVar ("CoreNodes", CoreNodes);
+  out.WriteVar ("Occupancy", Occupancy);
+  out.WriteVar ("Weight", Weight);
+  out.WriteVar ("Energy", Energy);
   //  out.WriteVar ("PartialNorm", PartialNorm);
-  out.WriteVar("Label", Label);
+  out.WriteVar ("Label", Label);
 }
 
 // This function assumes the grid has already been set.
-void RadialWF::Read(IOSectionClass& in)
+void 
+RadialWF::Read (IOSectionClass &in)
 {
   bool succ;
-  if (u.grid == NULL)
-  {
+  if (u.grid == NULL) {
     std::cerr << "Grid not set prior to calling RadialWF::Read.\n";
     exit(1);
   }
-  in.ReadVar("u", u.Data());
-  in.ReadVar("dudr", dudr.Data());
+  in.ReadVar ("u", u.Data());
+  in.ReadVar ("dudr", dudr.Data());
   assert(in.ReadVar("n", n));
   assert(in.ReadVar("l", l));
   assert(in.ReadVar("Occupancy", Occupancy));

--- a/src/QMCTools/ppconvert/src/common/RadialWF.h
+++ b/src/QMCTools/ppconvert/src/common/RadialWF.h
@@ -33,7 +33,7 @@ private:
   Potential* pot;
 
 public:
-  Grid* grid;
+  std::shared_ptr<Grid> grid;
   CubicSplineCommon u, dudr;
   int n, l, CoreNodes;
   double Energy, Occupancy, Weight;
@@ -49,7 +49,7 @@ public:
   double LogDerivative();
   void Solve(double tolerance = 1.0e-8);
   void Normalize();
-  void SetGrid(Grid* newgrid);
+  void SetGrid(std::shared_ptr<Grid>& newgrid);
   void SetPotential(Potential* newPot);
   Potential* GetPotential();
   void Write(IOSectionClass& out);

--- a/src/QMCTools/ppconvert/src/common/SplinePot.cc
+++ b/src/QMCTools/ppconvert/src/common/SplinePot.cc
@@ -8,8 +8,8 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-
-
+    
+    
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
@@ -19,10 +19,9 @@ double SplinePot::V(double r)
 {
   if (r <= Spline.grid->End)
     return Spline(r);
-  else if (Vouter != NULL)
+  else if (Vouter != NULL) 
     return (Vouter->V(r));
-  else
-  {
+  else {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -34,10 +33,9 @@ double SplinePot::dVdr(double r)
 {
   if (r <= Spline.grid->End)
     return Spline.Deriv(r);
-  else if (Vouter != NULL)
+  else if (Vouter != NULL) 
     return (Vouter->dVdr(r));
-  else
-  {
+  else {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -49,10 +47,9 @@ double SplinePot::d2Vdr2(double r)
 {
   if (r <= Spline.grid->End)
     return Spline.Deriv2(r);
-  else if (Vouter != NULL)
+  else if (Vouter != NULL) 
     return (Vouter->d2Vdr2(r));
-  else
-  {
+  else {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -60,34 +57,32 @@ double SplinePot::d2Vdr2(double r)
   }
 }
 
-void SplinePot::Read(IOSectionClass& in)
+void SplinePot::Read(IOSectionClass &in)
 {
   assert(in.OpenSection("Grid"));
   auto grid = ReadGrid(in);
-  in.CloseSection(); // "Grid"
-  Array<double, 1> data;
+  in.CloseSection(); // "Grid" 
+  Array<double,1> data;
   assert(in.ReadVar("SplineData", data));
-  Spline.Init(grid, data);
-  if (in.OpenSection("Vouter"))
-  {
+  Spline.Init (grid, data);
+  if(in.OpenSection("Vouter")) {
     Vouter = ReadPotential(in);
     in.CloseSection();
   }
   else
     Vouter = NULL;
-}
+ }
 
 
-void SplinePot::Write(IOSectionClass& out)
+void SplinePot::Write(IOSectionClass &out)
 {
-  out.WriteVar("Type", "Spline");
+  out.WriteVar ("Type", "Spline");
   out.NewSection("Grid");
   Spline.grid->Write(out);
   out.CloseSection();
-  out.WriteVar("SplineData", Spline.Data());
-  if (Vouter != NULL)
-  {
-    out.NewSection("Vouter");
+  out.WriteVar ("SplineData", Spline.Data());
+  if (Vouter != NULL) {
+    out.NewSection ("Vouter");
     Vouter->Write(out);
     out.CloseSection();
   }

--- a/src/QMCTools/ppconvert/src/common/SplinePot.cc
+++ b/src/QMCTools/ppconvert/src/common/SplinePot.cc
@@ -8,8 +8,8 @@
 //
 // File created by: Paul R. C. Kent, kentpr@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 //           http://pathintegrals.info                     //
 /////////////////////////////////////////////////////////////
 
@@ -19,9 +19,10 @@ double SplinePot::V(double r)
 {
   if (r <= Spline.grid->End)
     return Spline(r);
-  else if (Vouter != NULL) 
+  else if (Vouter != NULL)
     return (Vouter->V(r));
-  else {
+  else
+  {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -33,9 +34,10 @@ double SplinePot::dVdr(double r)
 {
   if (r <= Spline.grid->End)
     return Spline.Deriv(r);
-  else if (Vouter != NULL) 
+  else if (Vouter != NULL)
     return (Vouter->dVdr(r));
-  else {
+  else
+  {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -47,9 +49,10 @@ double SplinePot::d2Vdr2(double r)
 {
   if (r <= Spline.grid->End)
     return Spline.Deriv2(r);
-  else if (Vouter != NULL) 
+  else if (Vouter != NULL)
     return (Vouter->d2Vdr2(r));
-  else {
+  else
+  {
 #ifdef BZ_DEBUG
     cerr << "r outside grid in SplinePot:  " << r << endl;
 #endif
@@ -57,32 +60,34 @@ double SplinePot::d2Vdr2(double r)
   }
 }
 
-void SplinePot::Read(IOSectionClass &in)
+void SplinePot::Read(IOSectionClass& in)
 {
   assert(in.OpenSection("Grid"));
-  Grid *grid = ReadGrid(in);
-  in.CloseSection(); // "Grid" 
-  Array<double,1> data;
+  auto grid = ReadGrid(in);
+  in.CloseSection(); // "Grid"
+  Array<double, 1> data;
   assert(in.ReadVar("SplineData", data));
-  Spline.Init (grid, data);
-  if(in.OpenSection("Vouter")) {
+  Spline.Init(grid, data);
+  if (in.OpenSection("Vouter"))
+  {
     Vouter = ReadPotential(in);
     in.CloseSection();
   }
   else
     Vouter = NULL;
- }
+}
 
 
-void SplinePot::Write(IOSectionClass &out)
+void SplinePot::Write(IOSectionClass& out)
 {
-  out.WriteVar ("Type", "Spline");
+  out.WriteVar("Type", "Spline");
   out.NewSection("Grid");
   Spline.grid->Write(out);
   out.CloseSection();
-  out.WriteVar ("SplineData", Spline.Data());
-  if (Vouter != NULL) {
-    out.NewSection ("Vouter");
+  out.WriteVar("SplineData", Spline.Data());
+  if (Vouter != NULL)
+  {
+    out.NewSection("Vouter");
     Vouter->Write(out);
     out.CloseSection();
   }


### PR DESCRIPTION
Using `std::shared_ptr` to enable copy constructors and shared ownership.
Some automated clang-format (v10). 